### PR TITLE
Fix invalid opus player status change (#157)

### DIFF
--- a/nugu-android-helper/src/main/java/com/skt/nugu/sdk/external/silvertray/NuguOpusPlayer.kt
+++ b/nugu-android-helper/src/main/java/com/skt/nugu/sdk/external/silvertray/NuguOpusPlayer.kt
@@ -71,6 +71,9 @@ class NuguOpusPlayer(private val streamType: Int) : AttachmentPlayablePlayer {
                 listener.onPlaybackPaused(currentSourceId)
             }
             Status.ENDED -> {
+                if(prevStatus == Status.READY) {
+                    listener.onPlaybackStarted(currentSourceId)
+                }
                 listener.onPlaybackFinished(currentSourceId)
             }
             else -> {


### PR DESCRIPTION
If enter to ENDED after READY without STARTED,
call onPlaybackStarted().