### PR TITLE
Fix not notify audio player state changes (#194)

### DIFF
--- a/app/src/main/java/com/skt/nugu/sampleapp/template/TemplateFragment.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/template/TemplateFragment.kt
@@ -28,6 +28,7 @@ import com.skt.nugu.sampleapp.R
 import com.skt.nugu.sampleapp.client.ClientManager
 import com.skt.nugu.sampleapp.template.view.AbstractDisplayView
 import com.skt.nugu.sampleapp.template.view.DisplayAudioPlayer
+import com.skt.nugu.sdk.core.utils.Logger
 
 internal class TemplateFragment : Fragment(), AudioPlayerAgentInterface.Listener {
     companion object {
@@ -124,6 +125,7 @@ internal class TemplateFragment : Fragment(), AudioPlayerAgentInterface.Listener
     }
 
     override fun onStateChanged(activity: AudioPlayerAgentInterface.State, context: AudioPlayerAgentInterface.Context) {
+        Log.d(TAG, "[onStateChanged] activity: $activity")
         updatePlayButton(activity)
     }
 


### PR DESCRIPTION
add notifyOnReleaseAudioInfo() to remove duplication.

== Cause (example)
1. executeStop(true)
2. onPlaybackStopped(id=1)
3. executePlayNextItem()
<== current source id changed(id=2) and next item became null.
4. executeOnPlaybackStopped(id=1)
<== id 1 and 2 not equal. so event skipped.

== Solution
Do not call executePlayNextItem.
The next item will be play after stop finished by executeStop(true).