### PR TITLE
Fix isStartListeningWithTrigger flag (#196)

### DIFF
--- a/nugu-android-helper/src/main/java/com/skt/nugu/sdk/platform/android/speechrecognizer/SpeechRecognizerAggregator.kt
+++ b/nugu-android-helper/src/main/java/com/skt/nugu/sdk/platform/android/speechrecognizer/SpeechRecognizerAggregator.kt
@@ -133,7 +133,12 @@ class SpeechRecognizerAggregator(
     private val isStartListeningWithTriggering = AtomicBoolean(false)
 
     override fun startListeningWithTrigger() {
-        if(isStartListeningWithTriggering.compareAndSet(false, true) && keywordDetectorState == KeywordDetectorStateObserver.State.INACTIVE) {
+        if(isStartListeningWithTriggering.compareAndSet(false, true)) {
+            if(keywordDetectorState == KeywordDetectorStateObserver.State.ACTIVE) {
+                isStartListeningWithTriggering.compareAndSet(true, false)
+                return
+            }
+
             val inputStream = audioProvider.acquireAudioInputStream(keywordDetector)
             Log.d(TAG, "[startListeningWithTrigger] start with input stream - $inputStream")
 
@@ -190,11 +195,11 @@ class SpeechRecognizerAggregator(
                         if(!result.get()) {
                             it.release()
                         }
-                        isStartListeningWithTriggering.set(false)
+                        isStartListeningWithTriggering.compareAndSet(true, false)
                     }
                 }
             } else {
-                isStartListeningWithTriggering.set(false)
+                isStartListeningWithTriggering.compareAndSet(true, false)
             }
         } else {
             Log.d(TAG, "[startListeningWithTrigger] failed - already executing")


### PR DESCRIPTION
Not safe at :

1. If compareAndSet(false, true) success and state is ACTIVE,
then keyword detector do not executed. But flag set to true already.
So, cannot execute keyword detector anymore.

2. AtomicBoolean's set not atomic operation(just volatile)