### PR TITLE
Fix issus for blocking at SDS'reader (#211)

### DIFF
--- a/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/sds/CircularBufferSharedDataStream.kt
+++ b/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/sds/CircularBufferSharedDataStream.kt
@@ -53,7 +53,6 @@ open class CircularBufferSharedDataStream(private val capacity: Int) :
     private var isBufferFullFilled = false
 
     private val isWriterCreated = AtomicBoolean(false)
-    private lateinit var writer: SharedDataStream.Writer
 
     // get absolute position at stream
     override fun getPosition(): Long = fillCount * capacity + writeOffset
@@ -61,16 +60,15 @@ open class CircularBufferSharedDataStream(private val capacity: Int) :
     override fun createWriter(): SharedDataStream.Writer {
         if (isWriterCreated.compareAndSet(false, true)) {
             writerCount++
-            writer = MyWriter()
-            Logger.d(
-                TAG,
-                "[createWriter] refCount: $writerCount / created writer: $writer / refStream: $this"
-            )
+            return MyWriter().also {
+                Logger.d(
+                    TAG,
+                    "[createWriter] refCount: $writerCount / created writer: $it / refStream: $this"
+                )
+            }
         } else {
-            writer
+            throw IllegalStateException("Already the writer created. only a writer allowed.")
         }
-
-        return writer
     }
 
     override fun createReader(initialPosition: Long?): SharedDataStream.Reader {

--- a/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/sds/CircularBufferSharedDataStream.kt
+++ b/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/sds/CircularBufferSharedDataStream.kt
@@ -219,7 +219,7 @@ open class CircularBufferSharedDataStream(private val capacity: Int) :
 
                 if (read == 0 && !isClosing.get()) {
                     synchronized(waitLock) {
-                        if (!isClosing.get()) {
+                        if (!isClosing.get() && !isBufferFullFilled) {
                             waitLock.wait()
                         }
                     }

--- a/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/sds/CircularBufferSharedDataStream.kt
+++ b/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/sds/CircularBufferSharedDataStream.kt
@@ -48,6 +48,8 @@ open class CircularBufferSharedDataStream(private val capacity: Int) :
     private var readerCount = 0
     @Volatile
     private var writerCount = 0
+    @Volatile
+    private var isBufferFullFilled = false
 
     // get absolute position at stream
     override fun getPosition(): Long = fillCount * capacity + writeOffset
@@ -127,6 +129,8 @@ open class CircularBufferSharedDataStream(private val capacity: Int) :
     }
 
     private fun notifyBufferFullFilled() {
+        isBufferFullFilled = true
+
         synchronized(bufferEventListeners) {
             bufferEventListeners.forEach {
                 it.onBufferFullFilled()
@@ -141,9 +145,6 @@ open class CircularBufferSharedDataStream(private val capacity: Int) :
         private val TAG = "MyReader"
         private val isClosing = AtomicBoolean(false)
         private var isReading = false
-
-        @Volatile
-        private var isBufferFullFilled = false
 
         private val waitLock = Object()
 
@@ -257,7 +258,6 @@ open class CircularBufferSharedDataStream(private val capacity: Int) :
         }
 
         override fun onBufferFullFilled() {
-            isBufferFullFilled = true
             wakeLock()
         }
 


### PR DESCRIPTION
If reader start to read buffer after writer closed,
reader wait and not notified forever.

so, we check buffer full(writer closed or not) before wait.