### PR TITLE
Revert #258 partially.

### DIFF
--- a/nugu-core/src/main/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveGroupProcessor.kt
+++ b/nugu-core/src/main/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveGroupProcessor.kt
@@ -33,11 +33,11 @@ class DirectiveGroupProcessor(
             processedDirectives = it.preprocess(processedDirectives)
         }
 
+        inputProcessorManager.onReceiveDirectives(processedDirectives)
+        
         processedDirectives.forEach {
             directiveSequencer.onDirective(it)
         }
-
-        inputProcessorManager.onReceiveDirectives(processedDirectives)
     }
 
     override fun addDirectiveGroupPreprocessor(directiveGroupPreprocessor: DirectiveGroupPreprocessor) {


### PR DESCRIPTION
Revert following:
To prevent too fast release of focus,
change the order in which directives are delivered.

Why: Because the InputProcessorManager manage request and response,
should receive directives before request sequencing.

Issue(Too fast release of focus) should be solve by other way.