### PR TITLE
Fix wrong resume issue on focus change (#266)

### DIFF
--- a/nugu-android-helper/src/main/java/com/skt/nugu/sdk/platform/android/NuguAndroidClient.kt
+++ b/nugu-android-helper/src/main/java/com/skt/nugu/sdk/platform/android/NuguAndroidClient.kt
@@ -336,6 +336,7 @@ class NuguAndroidClient private constructor(
                         }
 
 
+                        getDirectiveGroupProcessor().addListener(this)
                         getDirectiveSequencer().addDirectiveHandler(this)
                     }
                 }


### PR DESCRIPTION
Issue:
1. asr acquire focus
2. audio player go to background and paused.
3. when asr finished (receive response), asr release focus
4. audio player become foreground.
5. audio player try to resume current item.

Solve:
Audio player look into received response before become foreground.
If exist AudioPlayer's playback directive in received response,
do not resume.