### PR TITLE
Prevent focus loss between DM and TTS (#346)

### DIFF
--- a/nugu-android-helper/src/main/java/com/skt/nugu/sdk/platform/android/NuguAndroidClient.kt
+++ b/nugu-android-helper/src/main/java/com/skt/nugu/sdk/platform/android/NuguAndroidClient.kt
@@ -356,6 +356,7 @@ class NuguAndroidClient private constructor(
                         DefaultFocusChannel.DIALOG_CHANNEL_NAME
                     ).apply {
                         getDirectiveSequencer().addDirectiveHandler(this)
+                        dialogUXStateAggregator.addListener(this)
                     }
                 }
             })


### PR DESCRIPTION
If release focus immediately after tts finish,
can be occur temporal focus changes.

To prevent it, release focus of tts when dialog state became IDLE.