### PR TITLE
Fix tts player not work using two or more (#384)

### DIFF
--- a/nugu-android-helper/src/main/java/com/skt/nugu/sdk/external/silvertray/RawCBRStreamSource.kt
+++ b/nugu-android-helper/src/main/java/com/skt/nugu/sdk/external/silvertray/RawCBRStreamSource.kt
@@ -33,12 +33,12 @@ internal class RawCBRStreamSource(private val attachmentReader: Attachment.Reade
         private const val FRAME_SIZE = 960
         private const val MAX_FRAME_SIZE = FRAME_SIZE * 3
         private const val HEADER_BUFFER_SIZE = 8
-        // Global thread
-        private val readAttachmentThread = Executors.newSingleThreadExecutor()
     }
 
     private val inputStream = PipedInputStream()
     private val outputStream = PipedOutputStream()
+
+    private val readAttachmentThread = Executors.newSingleThreadExecutor()
     private var readAttachmentFuture: Future<*>? = null
 
     init {


### PR DESCRIPTION
RawCBRStreamSource use a global thread to read & write.

In case of a player paused, the player will not read and a thread
blocked (waiting to finish read).

When the other player try to start read, it will not be started forever.

So, we use a new thread per instance.