### PR TITLE
Apply observer to gather play context (#393)

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultDisplayAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultDisplayAgent.kt
@@ -40,7 +40,6 @@ class DefaultDisplayAgent(
     private val contextManager: ContextManagerInterface,
     private val messageSender: MessageSender,
     private val playSynchronizer: PlaySynchronizerInterface,
-    private val playStackManager: PlayStackManagerInterface,
     private val inputProcessorManager: InputProcessorManagerInterface,
     private val playStackPriority: Int,
     enableDisplayLifeCycleManagement: Boolean
@@ -48,7 +47,8 @@ class DefaultDisplayAgent(
     , DisplayAgentInterface
     , InputProcessor
     , ControlFocusDirectiveHandler.Controller
-    , ControlScrollDirectiveHandler.Controller {
+    , ControlScrollDirectiveHandler.Controller
+    , PlayStackManagerInterface.PlayContextProvider {
     companion object {
         private const val TAG = "DisplayTemplateAgent"
 
@@ -494,9 +494,6 @@ class DefaultDisplayAgent(
 
     private fun releaseSyncImmediately(info: TemplateDirectiveInfo) {
         playSynchronizer.releaseSyncImmediately(info, info.onReleaseCallback)
-        info.playContext?.let {
-            playStackManager.remove(it)
-        }
     }
 
     private fun executeRender(info: TemplateDirectiveInfo) {
@@ -600,9 +597,7 @@ class DefaultDisplayAgent(
                 controller?.let { templateController ->
                     templateControllerMap[templateId] = templateController
                 }
-                it.playContext?.let { playContext ->
-                    playStackManager.add(playContext)
-                }
+
                 setHandlingCompleted(it)
             }
         }
@@ -871,5 +866,11 @@ class DefaultDisplayAgent(
         })
 
         return future.get()
+    }
+
+    override fun getPlayContext(): PlayStackManagerInterface.PlayContext? {
+        val playContext = currentInfo?.playContext
+        Logger.d(TAG, "[getPlayContext] $playContext")
+        return playContext
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/AudioPlayerTemplateHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/AudioPlayerTemplateHandler.kt
@@ -30,9 +30,11 @@ import java.util.concurrent.*
 
 class AudioPlayerTemplateHandler(
     private val playSynchronizer: PlaySynchronizerInterface,
-    private val playStackManager: PlayStackManagerInterface,
     private val playStackPriority: Int
-) : AbstractDirectiveHandler(), AudioPlayerDisplayInterface, AudioPlayerMetadataDirectiveHandler.Listener {
+) : AbstractDirectiveHandler()
+    , AudioPlayerDisplayInterface
+    , AudioPlayerMetadataDirectiveHandler.Listener
+    , PlayStackManagerInterface.PlayContextProvider{
     companion object {
         private const val TAG = "AudioPlayerTemplateHandler"
         const val NAMESPACE = DefaultAudioPlayerAgent.NAMESPACE
@@ -174,9 +176,6 @@ class AudioPlayerTemplateHandler(
 
     private fun releaseSyncForce(info: TemplateDirectiveInfo) {
         playSynchronizer.releaseSyncImmediately(info, info.onReleaseCallback)
-        info.playContext?.let {
-            playStackManager.remove(it)
-        }
     }
 
     private fun executeRender(info: TemplateDirectiveInfo) {
@@ -222,9 +221,6 @@ class AudioPlayerTemplateHandler(
                     })
                 controller?.let { templateController ->
                     templateControllerMap[templateId] = templateController
-                }
-                it.playContext?.let {playContext->
-                    playStackManager.add(playContext)
                 }
             }
         }
@@ -320,4 +316,6 @@ class AudioPlayerTemplateHandler(
             renderer?.update(info.getTemplateId(), jsonMetaData)
         }
     }
+
+    override fun getPlayContext(): PlayStackManagerInterface.PlayContext? = currentInfo?.playContext
 }

--- a/nugu-android-helper/src/main/java/com/skt/nugu/sdk/platform/android/NuguAndroidClient.kt
+++ b/nugu-android-helper/src/main/java/com/skt/nugu/sdk/platform/android/NuguAndroidClient.kt
@@ -330,7 +330,6 @@ class NuguAndroidClient private constructor(
                         getContextManager(),
                         playbackRouter,
                         getPlaySynchronizer(),
-                        getAudioPlayStackManager(),
                         DefaultFocusChannel.CONTENT_CHANNEL_NAME,
                         DefaultFocusChannel.CONTENT_CHANNEL_PRIORITY,
                         builder.enableDisplayLifeCycleManagement
@@ -346,9 +345,9 @@ class NuguAndroidClient private constructor(
 
                         AudioPlayerTemplateHandler(
                             getPlaySynchronizer(),
-                            getDisplayPlayStackManager(),
                             DefaultFocusChannel.CONTENT_CHANNEL_PRIORITY
                         ).apply {
+                            getDisplayPlayStackManager().addPlayContextProvider(this)
                             setDisplay(this)
                             getDirectiveSequencer().addDirectiveHandler(this)
                             getDirectiveGroupProcessor().addDirectiveGroupPreprocessor(
@@ -357,7 +356,7 @@ class NuguAndroidClient private constructor(
                             audioPlayerMetadataDirectiveHandler.addListener(this)
                         }
 
-
+                        getAudioPlayStackManager().addPlayContextProvider(this)
                         getDirectiveGroupProcessor().addPostProcessedListener(this)
                         getDirectiveSequencer().addDirectiveHandler(this)
                     }
@@ -372,11 +371,11 @@ class NuguAndroidClient private constructor(
                         getAudioFocusManager(),
                         getContextManager(),
                         getPlaySynchronizer(),
-                        getAudioPlayStackManager(),
                         getInputManagerProcessor(),
                         DefaultFocusChannel.DIALOG_CHANNEL_NAME,
                         DefaultFocusChannel.DIALOG_CHANNEL_PRIORITY
                     ).apply {
+                        getAudioPlayStackManager().addPlayContextProvider(this)
                         getDirectiveSequencer().addDirectiveHandler(this)
                         dialogUXStateAggregator.addListener(this)
                     }
@@ -487,11 +486,11 @@ class NuguAndroidClient private constructor(
                         getContextManager(),
                         getMessageSender(),
                         getPlaySynchronizer(),
-                        getDisplayPlayStackManager(),
                         getInputManagerProcessor(),
                         DefaultFocusChannel.DIALOG_CHANNEL_PRIORITY,
                         builder.enableDisplayLifeCycleManagement
                     ).apply {
+                        getDisplayPlayStackManager().addPlayContextProvider(this)
                         getDirectiveSequencer().addDirectiveHandler(this)
 
                         ControlFocusDirectiveHandler(this, getContextManager(), getMessageSender(), namespaceAndName).apply {

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/PlayStackManagerInterface.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/PlayStackManagerInterface.kt
@@ -18,12 +18,16 @@ package com.skt.nugu.sdk.core.interfaces.context
 interface PlayStackManagerInterface {
     data class PlayContext(
         val playServiceId: String,
-        val priority: Int
+        val priority: Int,
+        val persistent: Boolean = true
     ): Comparable<PlayContext> {
         override fun compareTo(other: PlayContext): Int = other.priority - priority
     }
 
-    fun add(playContext: PlayContext)
-    fun remove(playContext: PlayContext)
-    fun removeDelayed(playContext: PlayContext, delay: Long)
+    interface PlayContextProvider {
+        fun getPlayContext(): PlayContext?
+    }
+
+    fun addPlayContextProvider(provider: PlayContextProvider)
+    fun removePlayContextProvider(provider: PlayContextProvider)
 }


### PR DESCRIPTION
Refactor a way to get play context.

Changes
from : Each agent update the play context when changed.
to : The manager ask current play context to each agent if necessary.