### PR TITLE
Handle tts error correctly (#518)

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/dialog/DialogUXStateAggregator.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/dialog/DialogUXStateAggregator.kt
@@ -101,6 +101,14 @@ class DialogUXStateAggregator(
         isTtsPreparing = true
     }
 
+    override fun onError(dialogRequestId: String) {
+        isTtsPreparing = false
+
+        executor.submit {
+            tryEnterIdleState()
+        }
+    }
+
     override fun onStateChanged(state: ASRAgentInterface.State) {
         Logger.d(TAG, "[onStateChanged-ASR] state: $state")
         asrState = state

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/tts/TTSAgentInterface.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/tts/TTSAgentInterface.kt
@@ -57,6 +57,11 @@ interface TTSAgentInterface {
          * @param dialogRequestId the dialog request id
          */
         fun onReceiveTTSText(text: String?, dialogRequestId: String)
+
+        /**
+         * Called when occur error after onReceiveTTSText
+         */
+        fun onError(dialogRequestId: String)
     }
 
     /** Add a listener to be called when a state changed.


### PR DESCRIPTION
Issue
if occur error before tts playing, dialogUXStateAggregator never return
to idle state.

Solve
notify error for tts to try return idle state.