### PR TITLE
Stop audio player when loss focus always (#539)

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
@@ -951,7 +951,7 @@ class DefaultAudioPlayerAgent(
         if (!mediaPlayer.stop(sourceId)) {
             Logger.e(TAG, "[executeOnPlaybackPlayingOnLostFocus] stop failed")
         } else {
-            Logger.d(TAG, "[executeOnPlaybackPlayingOnLostFocus] pause Succeeded")
+            Logger.d(TAG, "[executeOnPlaybackPlayingOnLostFocus] stop Succeeded")
         }
     }
 
@@ -1167,9 +1167,7 @@ class DefaultAudioPlayerAgent(
     }
 
     private fun executeOnNoneFocus() {
-        if (currentActivity.isActive()) {
-            executeStop()
-        }
+        executeStop()
     }
 
 


### PR DESCRIPTION
We check the player status before request stop.
However if exist fetched and play
called item, it will be playing even if loss focus.

So, we request stop always when loss focus without the status check.