### PR TITLE
Release resources when not used (#582)

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
@@ -350,6 +350,15 @@ class DefaultAudioPlayerAgent(
                         it.activeAudioInfo = nextAudioInfo
                     }
 
+                    with(nextAudioInfo.directive) {
+                        // consume
+                        if(nextAudioInfo.payload.sourceType == SourceType.ATTACHMENT) {
+                            getAttachmentReader()
+                        }
+                        // destroy
+                        destroy()
+                    }
+
                     // fetch only offset
                     executeFetchOffset(nextAudioInfo.payload.audioItem.stream.offsetInMilliseconds)
 


### PR DESCRIPTION
When resume player, attachment not used anymore.
So, consume it and remove immediately.