### PR TITLE
Fix wrong state value for context (#652)

### DIFF
--- a/app/src/main/java/com/skt/nugu/sampleapp/client/ClientManager.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/client/ClientManager.kt
@@ -205,9 +205,9 @@ object ClientManager : AudioPlayerAgentInterface.Listener {
                 stateRequestToken: Int
             ) {
                 val wakeupWord = if (PreferenceHelper.triggerId(context) == 0) {
-                    "아리아"
+                    "\"아리아\""
                 } else {
-                    "팅커벨"
+                    "\"팅커벨\""
                 }
                 contextSetter.setState(
                     namespaceAndName,


### PR DESCRIPTION
wrap wakeup's value for context by double quotes(")