### PR TITLE
Close session if occur error

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/SpeechRecognizer.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/SpeechRecognizer.kt
@@ -18,6 +18,7 @@ package com.skt.nugu.sdk.agent.asr
 import com.skt.nugu.sdk.agent.asr.audio.AudioFormat
 import com.skt.nugu.sdk.agent.sds.SharedDataStream
 import com.skt.nugu.sdk.core.interfaces.message.Directive
+import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 interface SpeechRecognizer {
     enum class State {
@@ -34,10 +35,15 @@ interface SpeechRecognizer {
     }
 
     interface OnStateChangeListener {
-        fun onStateChanged(state: State)
+        fun onStateChanged(state: State, request: Request)
     }
 
     var enablePartialResult: Boolean
+
+    interface Request {
+        val eventMessage: EventMessageRequest
+        val sessionId: String?
+    }
 
     fun start(
         audioInputStream: SharedDataStream,
@@ -47,9 +53,8 @@ interface SpeechRecognizer {
         payload: ExpectSpeechPayload?,
         referrerDialogRequestId: String?,
         epdParam: EndPointDetectorParam,
-        recognitionCallback: ASRAgentInterface.StartRecognitionCallback?,
         resultListener: ASRAgentInterface.OnResultListener?
-    )
+    ): Request?
 
     fun stop(cancel: Boolean, cause: ASRAgentInterface.CancelCause)
 


### PR DESCRIPTION
To know about current request's detail, SpeechRecognizer.start return request object

When ExpectSpeech handling failure, try to close session if match with
current request.