### PR TITLE
Determine behavior for resume btn

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
@@ -612,9 +612,10 @@ class DefaultAudioPlayerAgent(
                     }
                 }
                 FocusState.BACKGROUND -> {
-                    // TODO : Should determine policy in this case.
-                    // Should be resume on foregrounded? If so, clear pause reason to resume on foreground.
-                    // pauseReason = null
+                    // The behavior should be same with when sent event.
+                    if(focusManager.acquireChannel(channelName, this, NAMESPACE)) {
+                        pauseReason = null
+                    }
                 }
                 FocusState.NONE -> {
                     // no-op


### PR DESCRIPTION
the behavior when resume btn pressed at background focus should be same
when sent resume event.

So, we request focus again.