### PR TITLE
Remove intent flag when starting NuguOAuthCallbackActivity

### DIFF
--- a/nugu-login-kit/src/main/java/com/skt/nugu/sdk/platform/android/login/auth/NuguOAuth.kt
+++ b/nugu-login-kit/src/main/java/com/skt/nugu/sdk/platform/android/login/auth/NuguOAuth.kt
@@ -323,7 +323,6 @@ class NuguOAuth private constructor(
         checkRedirectUri()
 
         Intent(activity, NuguOAuthCallbackActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
             activity.startActivityForResult(this, REQUEST_LOGIN)
         }
     }


### PR DESCRIPTION
#686 

1. FLAG_ACTIVITY_SINGLE_TOP is unused flag
2. FLAG_ACTIVITY_SINGLE_TOP is already set in the manifest
[In the source](https://github.com/nugu-developers/nugu-android/blob/master/nugu-login-kit/src/main/AndroidManifest.xml#L15)
```xml
   <activity
                android:name="com.skt.nugu.sdk.platform.android.login.auth.NuguOAuthCallbackActivity"
                android:excludeFromRecents="true"
                android:exported="true"
                android:launchMode="singleTop"
                android:noHistory="true"
                android:theme="@style/Nugu.NoDisplay">
```
