### PR TITLE
Ensure execution order for FocusManager (#703)

### DIFF
--- a/nugu-core/src/main/java/com/skt/nugu/sdk/core/focus/FocusManager.kt
+++ b/nugu-core/src/main/java/com/skt/nugu/sdk/core/focus/FocusManager.kt
@@ -45,7 +45,7 @@ class FocusManager(
      */
     //@GuardedBy("activeChannels")
     private val activeChannels = TreeSet<Channel>()
-    private val executor = DequeSingleThreadExecutor()
+    private val executor = Executors.newSingleThreadExecutor()
 
     private val listeners = CopyOnWriteArraySet<FocusManagerInterface.OnFocusChangedListener>()
 
@@ -92,16 +92,6 @@ class FocusManager(
         })
     }
 
-    override fun stopForegroundActivity() {
-        val foregroundChannel = getHighestPriorityActiveChannel()
-        if (foregroundChannel == null) {
-            return
-        }
-
-        executor.submitFirst {
-            stopForegroundActivityHelper(foregroundChannel, foregroundChannel.getInterfaceName())
-        }
-    }
 
     private fun acquireChannelHelper(
         channelToAcquire: Channel,

--- a/nugu-core/src/test/java/com/skt/nugu/sdk/core/focus/FocusManagerTest.kt
+++ b/nugu-core/src/test/java/com/skt/nugu/sdk/core/focus/FocusManagerTest.kt
@@ -240,7 +240,6 @@ class FocusManagerTest : FocusChangeManager() {
         )
         assertFocusChange(dialogClient, FocusState.FOREGROUND)
 
-        focusManager.stopForegroundActivity()
         assertFocusChange(dialogClient, FocusState.NONE)
     }
 
@@ -273,15 +272,12 @@ class FocusManagerTest : FocusChangeManager() {
         )
         assertFocusChange(contentClient, FocusState.BACKGROUND)
 
-        focusManager.stopForegroundActivity()
         assertFocusChange(dialogClient, FocusState.NONE)
         assertFocusChange(alertsClient, FocusState.FOREGROUND)
 
-        focusManager.stopForegroundActivity()
         assertFocusChange(alertsClient, FocusState.NONE)
         assertFocusChange(contentClient, FocusState.FOREGROUND)
 
-        focusManager.stopForegroundActivity()
         assertFocusChange(contentClient, FocusState.NONE)
     }
 
@@ -296,7 +292,6 @@ class FocusManagerTest : FocusChangeManager() {
         )
         assertFocusChange(dialogClient, FocusState.FOREGROUND)
 
-        focusManager.stopForegroundActivity()
         assertFocusChange(dialogClient, FocusState.NONE)
 
         Assert.assertTrue(
@@ -408,7 +403,6 @@ class FocusManagerTest : FocusChangeManager() {
             )
         }
 
-        focusManager.stopForegroundActivity()
         assertFocusChange(dialogClient, FocusState.NONE) //  wait focus changed
         assertFocusChange(contentClient, FocusState.FOREGROUND) //  wait focus changed
         for (listener in listeners) {
@@ -472,7 +466,5 @@ class FocusManagerTest : FocusChangeManager() {
         while (activeListeners.isNotEmpty()) {
             focusManager.removeListener(activeListeners.removeAt(0))
         }
-
-        focusManager.stopForegroundActivity()
     }
 }

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/focus/FocusManagerInterface.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/focus/FocusManagerInterface.kt
@@ -31,8 +31,6 @@ interface FocusManagerInterface {
     fun acquireChannel(channelName: String, channelObserver: ChannelObserver, interfaceName: String): Boolean
     fun releaseChannel(channelName: String, channelObserver: ChannelObserver): Future<Boolean>
 
-    fun stopForegroundActivity()
-
     fun addListener(listener: OnFocusChangedListener)
     fun removeListener(listener: OnFocusChangedListener)
 }


### PR DESCRIPTION
* ensure insertion order : use SingleThreadExecutor
* remove unused stopForegroundActivity API