### PR TITLE
Improve context update interface (#752)

### DIFF
--- a/app/src/main/java/com/skt/nugu/sampleapp/client/ClientManager.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/client/ClientManager.kt
@@ -36,6 +36,7 @@ import com.skt.nugu.sdk.platform.android.speechrecognizer.measure.SimplePcmPower
 import com.skt.nugu.sdk.core.interfaces.context.ClientContextProvider
 import com.skt.nugu.sdk.core.interfaces.directive.DirectiveSequencerInterface
 import com.skt.nugu.sdk.core.interfaces.message.Directive
+import com.skt.nugu.sdk.core.interfaces.context.ContextState
 import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.Executors
@@ -205,13 +206,17 @@ object ClientManager : AudioPlayerAgentInterface.Listener {
                 stateRequestToken: Int
             ) {
                 val wakeupWord = if (PreferenceHelper.triggerId(context) == 0) {
-                    "\"아리아\""
+                    "아리아"
                 } else {
-                    "\"팅커벨\""
+                    "팅커벨"
                 }
+
                 contextSetter.setState(
                     namespaceAndName,
-                    wakeupWord,
+                    object: ContextState {
+                        override fun toFullJsonString(): String = "\"$wakeupWord\""
+                        override fun toCompactJsonString(): String = toFullJsonString()
+                    },
                     StateRefreshPolicy.ALWAYS,
                     stateRequestToken
                 )

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultSoundAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultSoundAgent.kt
@@ -25,6 +25,7 @@ import com.skt.nugu.sdk.agent.version.Version
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextManagerInterface
 import com.skt.nugu.sdk.core.interfaces.context.ContextSetterInterface
+import com.skt.nugu.sdk.core.interfaces.context.ContextState
 import com.skt.nugu.sdk.core.interfaces.context.StateRefreshPolicy
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
@@ -66,11 +67,7 @@ class DefaultSoundAgent(
     private val executor = Executors.newSingleThreadExecutor()
 
     init {
-        contextManager.setStateProvider(namespaceAndName, this, buildCompactState().toString())
-    }
-
-    private fun buildCompactState() = JsonObject().apply {
-        addProperty("version", VERSION.toString())
+        contextManager.setStateProvider(namespaceAndName, this)
     }
 
     override fun provideState(
@@ -82,7 +79,14 @@ class DefaultSoundAgent(
             soundProvider.let {
                 contextSetter.setState(
                     namespaceAndName,
-                    buildCompactState().toString(),
+                    object: ContextState {
+                        val state = JsonObject().apply {
+                            addProperty("version", VERSION.toString())
+                        }.toString()
+
+                        override fun toFullJsonString(): String = state
+                        override fun toCompactJsonString(): String = state
+                    },
                     StateRefreshPolicy.NEVER,
                     stateRequestToken
                 )

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultSystemAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultSystemAgent.kt
@@ -25,10 +25,7 @@ import com.skt.nugu.sdk.agent.util.MessageFactory
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.connection.ConnectionManagerInterface
 import com.skt.nugu.sdk.core.interfaces.connection.ConnectionStatusListener
-import com.skt.nugu.sdk.core.interfaces.context.ContextManagerInterface
-import com.skt.nugu.sdk.core.interfaces.context.ContextRequester
-import com.skt.nugu.sdk.core.interfaces.context.ContextSetterInterface
-import com.skt.nugu.sdk.core.interfaces.context.StateRefreshPolicy
+import com.skt.nugu.sdk.core.interfaces.context.*
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.directive.DirectiveSequencerInterface
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
@@ -142,7 +139,7 @@ class DefaultSystemAgent(
          */
         directiveSequencer.addDirectiveHandler(this)
         directiveSequencer.addDirectiveHandler(RevokeDirectiveHandler(this))
-        contextManager.setStateProvider(namespaceAndName, this, buildCompactContext().toString())
+        contextManager.setStateProvider(namespaceAndName, this)
         onUserActive()
     }
 
@@ -189,14 +186,17 @@ class DefaultSystemAgent(
     ) {
         contextSetter.setState(
             namespaceAndName,
-            buildCompactContext().toString(),
+            object: ContextState {
+                val state = JsonObject().apply {
+                    addProperty("version", VERSION.toString())
+                }.toString()
+
+                override fun toFullJsonString(): String = state
+                override fun toCompactJsonString(): String = state
+            },
             StateRefreshPolicy.NEVER,
             stateRequestToken
         )
-    }
-
-    private fun buildCompactContext() = JsonObject().apply {
-        addProperty("version", VERSION.toString())
     }
 
     /**

--- a/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/NuguClient.kt
+++ b/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/NuguClient.kt
@@ -216,7 +216,7 @@ class NuguClient private constructor(
         namespaceAndName: NamespaceAndName,
         stateProvider: ContextStateProvider?
     ) {
-        contextStateProviderRegistry.setStateProvider(namespaceAndName, stateProvider, null)
+        contextStateProviderRegistry.setStateProvider(namespaceAndName, stateProvider)
     }
 
     fun addSystemAgentListener(listener: SystemAgentInterface.Listener) {

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/ContextManagerInterface.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/ContextManagerInterface.kt
@@ -23,7 +23,7 @@ interface ContextGetterInterface {
 }
 
 interface ContextStateProviderRegistry {
-    fun setStateProvider(namespaceAndName: NamespaceAndName, stateProvider: ContextStateProvider?, compactState: String?)
+    fun setStateProvider(namespaceAndName: NamespaceAndName, stateProvider: ContextStateProvider?)
 }
 
 interface ContextManagerInterface

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/ContextState.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/ContextState.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ * Copyright (c) 2020 SK Telecom Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.skt.nugu.sdk.core.interfaces.context
 
-import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
-
-interface ContextSetterInterface {
-    enum class SetStateResult {
-        SUCCESS,
-        STATE_PROVIDER_NOT_REGISTERED,
-        STATE_TOKEN_OUTDATED
-    }
-
-    fun setState(
-        namespaceAndName: NamespaceAndName,
-        state: ContextState,
-        refreshPolicy: StateRefreshPolicy,
-        stateRequestToken: Int = 0
-    ): SetStateResult
+/**
+ * the context state
+ * Recommend to implement equals()/hashCode() for optimal performance.
+ */
+interface ContextState {
+    fun toFullJsonString(): String
+    fun toCompactJsonString(): String
 }

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/OsContextProvider.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/OsContextProvider.kt
@@ -34,7 +34,10 @@ abstract class OsContextProvider: ClientContextProvider {
     ) {
         contextSetter.setState(
             namespaceAndName,
-            "\"${getType().value}\"",
+            object: ContextState {
+                override fun toFullJsonString(): String = "\"${getType().value}\""
+                override fun toCompactJsonString(): String = toFullJsonString()
+            },
             StateRefreshPolicy.NEVER,
             stateRequestToken
         )


### PR DESCRIPTION
Change setState API interface to check equality of state at context
manager.

before: Each agent is responsible for optimizing context updates.
after: Each agent just pass context, then manager will update
optimally.