### PR TITLE
Improve AbstractDirectiveHandler (#820)

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/AbstractDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/AbstractDirectiveHandler.kt
@@ -51,7 +51,19 @@ abstract class AbstractDirectiveHandler: DirectiveHandler {
             return
         }
 
-        val info = createDirectiveInfo(directive, result)
+        val info = createDirectiveInfo(directive,
+            // wrap result to remove directive from map.
+            object : DirectiveHandlerResult {
+                override fun setCompleted() {
+                    directiveInfoMap.remove(messageId)
+                    result.setCompleted()
+                }
+
+                override fun setFailed(description: String, cancelAll: Boolean) {
+                    directiveInfoMap.remove(messageId)
+                    result.setFailed(description, cancelAll)
+                }
+            })
         directiveInfoMap[directive.getMessageId()] = info
 
         preHandleDirective(info)
@@ -80,8 +92,7 @@ abstract class AbstractDirectiveHandler: DirectiveHandler {
     private fun createDirectiveInfo(
         directive: Directive,
         result: DirectiveHandlerResult
-    ) =
-        DirectiveInfoImpl(
+    ) = DirectiveInfoImpl(
             directive,
             result
         )
@@ -105,6 +116,7 @@ abstract class AbstractDirectiveHandler: DirectiveHandler {
      * Remove directive from map which managed.
      * @param messageId the messageId for directive.
      */
+    @Deprecated("removed soon")
     protected fun removeDirective(messageId: String) {
         directiveInfoMap.remove(messageId)
     }


### PR DESCRIPTION
The class is easy to use incorrectly.
The implementer should call removeDirective() after finish handle.
<= An error-prone point.

So, wrap result object to remove directive from map.