### PR TITLE
Fix synchronization issue for LoopThread (#833)

### DIFF
--- a/nugu-core/src/main/java/com/skt/nugu/sdk/core/utils/LoopThread.kt
+++ b/nugu-core/src/main/java/com/skt/nugu/sdk/core/utils/LoopThread.kt
@@ -17,13 +17,18 @@ package com.skt.nugu.sdk.core.utils
 
 abstract class LoopThread : Thread() {
     private val wakeLoop = Object()
+    private var isNotified = false
 
     override fun run() {
         super.run()
 
         while (true) {
             synchronized(wakeLoop) {
-                wakeLoop.wait()
+                if(isNotified) {
+                    isNotified = false
+                } else {
+                    wakeLoop.wait()
+                }
             }
 
             onLoop()
@@ -34,12 +39,14 @@ abstract class LoopThread : Thread() {
 
     fun wakeOne() {
         synchronized(wakeLoop) {
+            isNotified = true
             wakeLoop.notify()
         }
     }
 
     fun wakeAll() {
         synchronized(wakeLoop) {
+            isNotified = true
             wakeLoop.notifyAll()
         }
     }


### PR DESCRIPTION
Problem
1. onLoop() finished.
2. not enter waiting yet.
3. client call wakeXXX() to run onLoop(), but not work.
4. enter waiting.

Solution
If notify called at not waiting, skip wait.