### PR TITLE
Fix ASR.ExpectSpeech canceled by tts' focus #1050

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultASRAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultASRAgent.kt
@@ -463,6 +463,7 @@ class DefaultASRAgent(
                     clearPreHandledExpectSpeech()
                     clearCurrentAttributeKeyIfMatchWith(it)
                 }
+                setState(ASRAgentInterface.State.IDLE)
             }
         } else {
             executeStopRecognitionOnAttributeUnset(messageId)
@@ -603,7 +604,14 @@ class DefaultASRAgent(
                 focusManager.release(userSpeechFocusRequester, FocusState.BACKGROUND)
                 focusManager.release(expectSpeechFocusRequester, FocusState.BACKGROUND)
             }
-            FocusState.NONE -> executeStopRecognition(true, ASRAgentInterface.CancelCause.LOSS_FOCUS)
+            FocusState.NONE -> {
+                if(state == ASRAgentInterface.State.EXPECTING_SPEECH) {
+                    expectSpeechDirectiveParam?.let {
+                        executeCancelExpectSpeechDirective(it.directive.header.messageId)
+                    }
+                }
+                executeStopRecognition(true, ASRAgentInterface.CancelCause.LOSS_FOCUS)
+            }
         }
     }
 


### PR DESCRIPTION
Issue
1. Receive TTS.Speak, ASR.ExpectSpeech
2. TTS.Speak start and finish.
3. ASR.ExpectSpeech start, but canceled
   since TTS.Speak's focus not released yet