### PR TITLE
Add ExternalViewRenderer Interface to support thing like MediaNotification

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,4 +94,10 @@ dependencies {
     implementation 'com.sothree.slidinguppanel:library:3.4.0'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1'
+
+    // Koin for Kotlin
+    implementation "org.koin:koin-core:2.0.1"
+    implementation "org.koin:koin-android:2.0.1"
+    implementation "org.koin:koin-android-viewmodel:2.0.1"
 }
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,4 +100,3 @@ dependencies {
     implementation "org.koin:koin-android:2.0.1"
     implementation "org.koin:koin-android-viewmodel:2.0.1"
 }
-

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
-          package="com.skt.nugu.sampleapp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.skt.nugu.sampleapp">
 
-    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:name=".application.SampleApplication"
@@ -18,21 +20,26 @@
         android:usesCleartextTraffic="true"
         tools:replace="android:allowBackup">
 
-        <activity android:name=".activity.LoginActivity" android:screenOrientation="portrait"
-                  android:configChanges="orientation|keyboardHidden">
+        <activity
+            android:name=".activity.LoginActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:screenOrientation="portrait">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <activity android:name=".activity.MainActivity" android:screenOrientation="portrait"
-                  android:theme="@style/AppTheme.NoActionBar"
-                  android:configChanges="orientation|keyboardHidden">
-        </activity>
+        <activity
+            android:name=".activity.MainActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:screenOrientation="portrait"
+            android:theme="@style/AppTheme.NoActionBar" />
 
-        <activity android:name=".activity.SettingsActivity" android:screenOrientation="portrait"
-                  android:configChanges="orientation|keyboardHidden"/>
+        <activity
+            android:name=".activity.SettingsActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:screenOrientation="portrait" />
 
         <activity android:name=".activity.IntroActivity" />
         <activity
@@ -50,9 +57,13 @@
             </intent-filter>
         </activity>
 
-        <activity
-            android:name=".activity.SettingsAgreementActivity"/>
+        <activity android:name=".activity.SettingsAgreementActivity" />
 
-        <service android:name=".service.MusicPlayerService"/>
+        <service android:name=".service.MusicPlayerService" />
+
+        <service
+            android:name=".service.SampleAppService"
+            android:enabled="true"
+            android:permission="android.permission.SYSTEM_ALERT_WINDOW"/>
     </application>
 </manifest>

--- a/app/src/main/java/com/skt/nugu/sampleapp/activity/MainActivity.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/activity/MainActivity.kt
@@ -15,12 +15,16 @@
  */
 package com.skt.nugu.sampleapp.activity
 
+import android.annotation.TargetApi
 import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.NetworkInfo
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.support.design.widget.CoordinatorLayout
+import android.provider.Settings
 import android.support.design.widget.NavigationView
 import android.support.v4.widget.DrawerLayout
 import android.support.v7.app.ActionBarDrawerToggle
@@ -30,7 +34,6 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
-import com.skt.nugu.sdk.agent.audioplayer.AudioPlayerAgentInterface
 import com.skt.nugu.sdk.core.interfaces.connection.ConnectionStatusListener
 import com.skt.nugu.sdk.platform.android.speechrecognizer.SpeechRecognizerAggregator
 import com.skt.nugu.sdk.platform.android.speechrecognizer.SpeechRecognizerAggregatorInterface
@@ -40,18 +43,18 @@ import com.skt.nugu.sampleapp.R
 import com.skt.nugu.sampleapp.client.ClientManager
 import com.skt.nugu.sampleapp.client.ExponentialBackOff
 import com.skt.nugu.sampleapp.client.TokenRefresher
-import com.skt.nugu.sampleapp.service.MusicPlayerService
-import com.skt.nugu.sdk.platform.android.ux.template.presenter.TemplateRenderer
+import com.skt.nugu.sampleapp.service.SampleAppService
 import com.skt.nugu.sampleapp.utils.*
 import com.skt.nugu.sdk.agent.system.SystemAgentInterface
-import com.skt.nugu.sdk.platform.android.NuguAndroidClient
 import com.skt.nugu.sdk.client.configuration.ConfigurationStore
+import com.skt.nugu.sdk.platform.android.NuguAndroidClient
 import com.skt.nugu.sdk.platform.android.login.auth.Credentials
 import com.skt.nugu.sdk.platform.android.login.auth.NuguOAuthError
+import com.skt.nugu.sdk.platform.android.ux.template.presenter.TemplateRenderer
 import com.skt.nugu.sdk.platform.android.ux.widget.*
 
 class MainActivity : AppCompatActivity(), SpeechRecognizerAggregatorInterface.OnStateChangeListener,
-    NavigationView.OnNavigationItemSelectedListener, ConnectionStatusListener, AudioPlayerAgentInterface.Listener, SystemAgentInterfaceListener,
+    NavigationView.OnNavigationItemSelectedListener, ConnectionStatusListener, SystemAgentInterfaceListener,
     TokenRefresher.Listener {
     companion object {
         private const val TAG = "MainActivity"
@@ -62,6 +65,12 @@ class MainActivity : AppCompatActivity(), SpeechRecognizerAggregatorInterface.On
 
         fun invokeActivity(context: Context) {
             context.startActivity(Intent(context, MainActivity::class.java))
+        }
+
+        val templateRenderer: TemplateRenderer by lazy {
+            TemplateRenderer(object : TemplateRenderer.NuguClientProvider {
+                override fun getNuguClient(): NuguAndroidClient = ClientManager.getClient()
+            }, ConfigurationStore.configuration.deviceTypeCode, null, R.id.template_container)
         }
     }
 
@@ -101,10 +110,6 @@ class MainActivity : AppCompatActivity(), SpeechRecognizerAggregatorInterface.On
         ClientManager.speechRecognizerAggregator
     }
 
-    private val templateRenderer =
-        TemplateRenderer(object : TemplateRenderer.NuguClientProvider {
-            override fun getNuguClient(): NuguAndroidClient = ClientManager.getClient()
-        }, ConfigurationStore.configuration.deviceTypeCode, supportFragmentManager, R.id.template_container)
     private val tokenRefresher = TokenRefresher(NuguOAuth.getClient())
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -114,10 +119,10 @@ class MainActivity : AppCompatActivity(), SpeechRecognizerAggregatorInterface.On
         SoundPoolCompat.load(this)
         // add observer for connection
         ClientManager.getClient().addConnectionListener(this)
-        // add observer for audioplayer
-        ClientManager.getClient().addAudioPlayerListener(this)
         // Set a renderer for display agent.
         ClientManager.getClient().setDisplayRenderer(templateRenderer.also {
+            it.setFragmentManager(supportFragmentManager)
+
             ConfigurationStore.templateServerUri { url, error ->
                 error?.apply {
                     Log.e(TAG, "[onCreate] error=$this")
@@ -163,6 +168,8 @@ class MainActivity : AppCompatActivity(), SpeechRecognizerAggregatorInterface.On
 
         tokenRefresher.setListener(this)
         tokenRefresher.start()
+
+        checkPermissionForOverlay()
     }
 
     override fun onResume() {
@@ -223,18 +230,17 @@ class MainActivity : AppCompatActivity(), SpeechRecognizerAggregatorInterface.On
         }
 
         SoundPoolCompat.release()
-        MusicPlayerService.stopService(this)
 
         // clear a renderer for display agent.
         ClientManager.getClient().setDisplayRenderer(null)
+        templateRenderer.setFragmentManager(null)
+
         // remove observer for connection
         ClientManager.getClient().removeConnectionListener(this)
         // remove listener for systemagent
         ClientManager.getClient().removeSystemAgentListener(this)
         // shutdown a server
-        ClientManager.getClient().shutdown()
-        // remove observer for audioplayer
-        ClientManager.getClient().removeAudioPlayerListener(this)
+//        ClientManager.getClient().shutdown()
 
         tokenRefresher.stop()
         super.onDestroy()
@@ -449,15 +455,6 @@ class MainActivity : AppCompatActivity(), SpeechRecognizerAggregatorInterface.On
         }
     }
 
-    override fun onStateChanged(activity: AudioPlayerAgentInterface.State, context: AudioPlayerAgentInterface.Context) {
-        runOnUiThread {
-            Log.d(TAG, "[onStateChanged-AudioPlayer] activity: $activity, context: $context")
-            if (activity == AudioPlayerAgentInterface.State.PLAYING) {
-                MusicPlayerService.startService(this, context)
-            }
-        }
-    }
-
     override fun onRevoke(reason: SystemAgentInterface.RevokeReason) {
         Log.d(TAG, "[onRevoke] The device has been revoked ($reason)")
         performRevoke()
@@ -603,5 +600,48 @@ class MainActivity : AppCompatActivity(), SpeechRecognizerAggregatorInterface.On
         val connMgr = this@MainActivity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val activeNetworkInfo: NetworkInfo? = connMgr.activeNetworkInfo
         return activeNetworkInfo?.isConnected ?: false
+    }
+
+    private fun checkPermissionForOverlay() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (!Settings.canDrawOverlays(this)) {
+                val intent = Intent(
+                    Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                    Uri.parse("package:$packageName")
+                )
+                startActivityForResult(intent, 1)
+            } else {
+                startService()
+            }
+        } else {
+            startService()
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == 1) {
+            if (!Settings.canDrawOverlays(this)) {
+                // todo. when disagree
+//                finish()
+            } else {
+                startService()
+            }
+        }
+    }
+
+    override fun onStop() {
+        SampleAppService.showFloating(applicationContext)
+        super.onStop()
+    }
+
+    override fun onStart() {
+        SampleAppService.hideFloating(applicationContext)
+        super.onStart()
+    }
+
+    private fun startService() {
+        SampleAppService.start(applicationContext)
     }
 }

--- a/app/src/main/java/com/skt/nugu/sampleapp/application/SampleApplication.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/application/SampleApplication.kt
@@ -16,24 +16,28 @@
 package com.skt.nugu.sampleapp.application
 
 import android.app.Application
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import android.util.Log
 import com.skt.nugu.sampleapp.client.ClientManager
+import com.skt.nugu.sampleapp.service.SampleNotificationChannel
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
 
 class SampleApplication : Application() {
     companion object {
         private const val TAG = "SampleApplication"
-
-        val NOTIFICATION_CHANNEL_MUSIC_PLAYER = "channel_0"
     }
 
     override fun onCreate() {
         super.onCreate()
         initializeClientManager()
         createNotificationChannel()
+
+        startKoin {
+            androidContext(this@SampleApplication)
+        }
     }
 
     /**
@@ -57,11 +61,8 @@ class SampleApplication : Application() {
         }
         Log.d(TAG, "[createNotificationChannel]")
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val notificationChannel = NotificationChannel(
-            NOTIFICATION_CHANNEL_MUSIC_PLAYER,
-            "Music Player Channel",
-            NotificationManager.IMPORTANCE_LOW
-        )
-        notificationManager.createNotificationChannel(notificationChannel)
+        SampleNotificationChannel.values().forEach {
+            notificationManager.createNotificationChannel(it.createChannel())
+        }
     }
 }

--- a/app/src/main/java/com/skt/nugu/sampleapp/service/MusicPlayerService.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/service/MusicPlayerService.kt
@@ -56,6 +56,8 @@ class MusicPlayerService : Service(), AudioPlayerAgentInterface.Listener {
         private const val ACTION_PREV = "ACTION_PREV"
         private const val ACTION_NEXT = "ACTION_NEXT"
         private const val ACTION_STOP = "ACTION_STOP"
+        private const val ACTION_CLOSE_NOTI = "ACTION_CLOSE_NOTI"
+
 
         fun startService(context: Context, audioItemContext: AudioPlayerAgentInterface.Context) {
             val intent = Intent(context.applicationContext, MusicPlayerService::class.java).apply {
@@ -72,7 +74,7 @@ class MusicPlayerService : Service(), AudioPlayerAgentInterface.Listener {
 
         fun stopService(context: Context) {
             val intent = Intent(context.applicationContext, MusicPlayerService::class.java)
-            intent.action = ACTION_STOP
+            intent.action = ACTION_CLOSE_NOTI
             context.startService(intent)
         }
     }
@@ -102,6 +104,7 @@ class MusicPlayerService : Service(), AudioPlayerAgentInterface.Listener {
             ACTION_PREV -> onActionPrev()
             ACTION_NEXT -> onActionNext()
             ACTION_STOP -> onActionStop()
+            ACTION_CLOSE_NOTI -> stopServiceSelf()
         }
 
         return super.onStartCommand(intent, flags, startId)
@@ -170,7 +173,7 @@ class MusicPlayerService : Service(), AudioPlayerAgentInterface.Listener {
         val builder: NotificationCompat.Builder = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             NotificationCompat.Builder(this)
         } else {
-            NotificationCompat.Builder(this, SampleApplication.NOTIFICATION_CHANNEL_MUSIC_PLAYER)
+            NotificationCompat.Builder(this, SampleNotificationChannel.MUSIC.channelId)
         }.apply {
             setSmallIcon(R.drawable.nugu_logo_72)
             setContent(remoteViews)

--- a/app/src/main/java/com/skt/nugu/sampleapp/service/SampleAppService.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/service/SampleAppService.kt
@@ -1,0 +1,143 @@
+package com.skt.nugu.sampleapp.service
+
+import android.app.Notification
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import android.support.v4.app.NotificationCompat
+import android.support.v4.content.ContextCompat
+import com.skt.nugu.sampleapp.R
+import com.skt.nugu.sampleapp.activity.MainActivity
+import com.skt.nugu.sampleapp.client.ClientManager
+import com.skt.nugu.sampleapp.service.floating.FloatingHeadWindow
+import com.skt.nugu.sdk.agent.audioplayer.AudioPlayerAgentInterface
+import com.skt.nugu.sdk.platform.android.ux.template.presenter.TemplateRenderer
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
+
+class SampleAppService : Service() {
+    companion object {
+        private const val TAG = "SampleAppService"
+
+        private const val ACTION_SERVICE_START = "ACTION_START"
+        private const val ACTION_SERVICE_STOP = "ACTION_STOP"
+        private const val ACTION_SHOW_FLOATING = "ACTION_SHOW_FLOATING"
+        private const val ACTION_HIDE_FLOATING = "ACTION_HIDE_FLOATING"
+
+        fun start(appContext: Context) {
+            ContextCompat.startForegroundService(appContext,
+                Intent(appContext, SampleAppService::class.java).also { it.action = ACTION_SERVICE_START })
+        }
+
+        fun stop(appContext: Context) {
+            ContextCompat.startForegroundService(appContext,
+                Intent(appContext, SampleAppService::class.java).also { it.action = ACTION_SERVICE_STOP })
+        }
+
+        fun showFloating(appContext: Context) {
+            ContextCompat.startForegroundService(appContext,
+                Intent(appContext, SampleAppService::class.java).also { it.action = ACTION_SHOW_FLOATING })
+        }
+
+        fun hideFloating(appContext: Context) {
+            ContextCompat.startForegroundService(appContext,
+                Intent(appContext, SampleAppService::class.java).also { it.action = ACTION_HIDE_FLOATING })
+        }
+    }
+
+    private val appContext: Context by inject()
+    lateinit var floatingHeadWindow: FloatingHeadWindow
+    private var medianNotiCancleJob: Job? = null
+    private var notifyingTemplateId: String? = null
+
+    private val notiRenderer = object : TemplateRenderer.ExternalViewRenderer {
+        override fun getVisibleList(): List<TemplateRenderer.ExternalViewRenderer.ViewInfo>? {
+            notifyingTemplateId.let { id ->
+                return if (id == null) null
+                else listOf(TemplateRenderer.ExternalViewRenderer.ViewInfo(id))
+            }
+        }
+    }
+
+    private val audioStateListener = object : AudioPlayerAgentInterface.Listener {
+        override fun onStateChanged(activity: AudioPlayerAgentInterface.State, context: AudioPlayerAgentInterface.Context) {
+            if (activity == AudioPlayerAgentInterface.State.PLAYING) {
+                MusicPlayerService.startService(appContext, context)
+                medianNotiCancleJob?.cancel()
+
+                notifyingTemplateId = context.templateId
+            } else if (activity == AudioPlayerAgentInterface.State.STOPPED) {
+                medianNotiCancleJob = GlobalScope.launch {
+                    delay(1000)
+                    MusicPlayerService.stopService(appContext)
+                }
+                notifyingTemplateId = null
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        startForeground()
+
+        initFloatingButton()
+        ClientManager.getClient().addAudioPlayerListener(audioStateListener)
+        MainActivity.templateRenderer.externalViewRenderer = notiRenderer
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        floatingHeadWindow.hide()
+        ClientManager.getClient().removeAudioPlayerListener(audioStateListener)
+        stopForeGround()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+
+        when (intent?.action) {
+            ACTION_SHOW_FLOATING -> floatingHeadWindow.show()
+            ACTION_HIDE_FLOATING -> floatingHeadWindow.hide()
+            ACTION_SERVICE_STOP -> stopForeGround()
+        }
+
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun initFloatingButton() {
+        if (!::floatingHeadWindow.isInitialized) {
+            floatingHeadWindow = FloatingHeadWindow(applicationContext).apply {
+                create()
+                createLayoutParams()
+            }
+        }
+    }
+
+    private fun startForeground() {
+        startForeground(123, SampleNoti(appContext).builder.build())
+    }
+
+    private fun stopForeGround() {
+        stopForeground(true)
+        stopSelf()
+    }
+
+    class SampleNoti(val context: Context) {
+        val builder: NotificationCompat.Builder by lazy {
+            NotificationCompat.Builder(context, SampleNotificationChannel.SAMPLE.channelId)
+                .setSmallIcon(R.drawable.nugu_logo_72)  // the status icon
+                .setOnlyAlertOnce(true)
+                .setOngoing(true)
+                .setSound(null)
+                .setPriority(Notification.PRIORITY_MAX)
+                .setContentText("nugu is running")
+                .setStyle(NotificationCompat.BigTextStyle().bigText(""))
+        }
+    }
+}

--- a/app/src/main/java/com/skt/nugu/sampleapp/service/SampleNotificationChannel.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/service/SampleNotificationChannel.kt
@@ -1,0 +1,26 @@
+package com.skt.nugu.sampleapp.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import android.support.annotation.RequiresApi
+
+
+enum class SampleNotificationChannel(
+    val channelId: String,
+    private val channelName: String,
+    private val channelImportance: Int = NotificationManager.IMPORTANCE_DEFAULT
+) {
+    MUSIC("channel_0", //The id of the channel. Must be unique per package.
+        "Music Player Channel", //The user visible name of the channel
+        NotificationManager.IMPORTANCE_LOW),
+
+    SAMPLE("sample",
+        "sample app"
+    );
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun createChannel() = NotificationChannel(channelId, channelName, channelImportance).apply {
+        setSound(null, null)
+    }
+}

--- a/app/src/main/java/com/skt/nugu/sampleapp/service/floating/FloatingHeadWindow.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/service/floating/FloatingHeadWindow.kt
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skt.nugu.sampleapp.service.floating
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.WindowManager
+import android.widget.TextView
+import com.skt.nugu.sampleapp.R
+import com.skt.nugu.sampleapp.activity.MainActivity
+import com.skt.nugu.sampleapp.client.ClientManager
+import com.skt.nugu.sdk.agent.asr.ASRAgentInterface
+import com.skt.nugu.sdk.agent.chips.RenderDirective
+import com.skt.nugu.sdk.agent.dialog.DialogUXStateAggregatorInterface
+import com.skt.nugu.sdk.core.interfaces.message.Header
+import com.skt.nugu.sdk.platform.android.ux.widget.NuguVoiceChromeView
+
+class FloatingHeadWindow(val context: Context) : FloatingView.Callbacks {
+
+    private var windowManager: WindowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    private lateinit var layoutParams: WindowManager.LayoutParams
+    private lateinit var view: View
+    private lateinit var sttView: TextView
+    private lateinit var nuguBtn: View
+    private lateinit var voiceChrome: NuguVoiceChromeView
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var isViewAdded = false
+
+    private val dialogStateListener = object : DialogUXStateAggregatorInterface.Listener {
+        override fun onDialogUXStateChanged(
+            newState: DialogUXStateAggregatorInterface.DialogUXState,
+            dialogMode: Boolean,
+            chips: RenderDirective.Payload?,
+            sessionActivated: Boolean
+        ) {
+
+            mainHandler.post {
+                when (newState) {
+                    DialogUXStateAggregatorInterface.DialogUXState.EXPECTING -> {
+                        showViewAndHideOthers(voiceChrome)
+                        voiceChrome.startAnimation(NuguVoiceChromeView.Animation.WAITING)
+                    }
+                    DialogUXStateAggregatorInterface.DialogUXState.LISTENING -> {
+                        if (sttView.text.isNullOrBlank()) {
+                            showViewAndHideOthers(voiceChrome)
+                            voiceChrome.startAnimation(NuguVoiceChromeView.Animation.LISTENING)
+                        }
+                    }
+                    DialogUXStateAggregatorInterface.DialogUXState.THINKING -> {
+//                        showViewAndHideOthers(voiceChrome)
+//                        voiceChrome.startAnimation(NuguVoiceChromeView.Animation.THINKING)
+                    }
+                    DialogUXStateAggregatorInterface.DialogUXState.SPEAKING -> {
+                        showViewAndHideOthers(voiceChrome)
+                        voiceChrome.startAnimation(NuguVoiceChromeView.Animation.SPEAKING)
+                    }
+                    DialogUXStateAggregatorInterface.DialogUXState.IDLE -> {
+                        showViewAndHideOthers(nuguBtn)
+                    }
+                }
+            }
+        }
+    }
+
+    private val asrResultListener = object : ASRAgentInterface.OnResultListener {
+        override fun onNoneResult(header: Header) {
+        }
+
+        override fun onPartialResult(result: String, header: Header) {
+            mainHandler.post {
+                showViewAndHideOthers(sttView)
+                sttView.text = result
+            }
+        }
+
+        override fun onCompleteResult(result: String, header: Header) {
+            mainHandler.post {
+                showViewAndHideOthers(sttView)
+                sttView.text = result
+            }
+        }
+
+        override fun onError(type: ASRAgentInterface.ErrorType, header: Header) {
+            mainHandler.post {
+                sttView.visibility = View.GONE
+                sttView.text = ""
+            }
+        }
+
+        override fun onCancel(cause: ASRAgentInterface.CancelCause, header: Header) {
+            mainHandler.post {
+                sttView.visibility = View.GONE
+                sttView.text = ""
+            }
+        }
+    }
+
+    fun show() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (Settings.canDrawOverlays(context)) {
+                windowManager.addView(view, layoutParams)
+            }
+        } else {
+            windowManager.addView(view, layoutParams)
+        }
+        isViewAdded = true
+
+        ClientManager.getClient().addDialogUXStateListener(dialogStateListener)
+        ClientManager.getClient().addASRResultListener(asrResultListener)
+    }
+
+    fun hide() {
+        if(view.isAttachedToWindow) {
+            windowManager.removeView(view)
+            isViewAdded = false
+
+            ClientManager.getClient().removeDialogUXStateListener(dialogStateListener)
+            ClientManager.getClient().removeASRResultListener(asrResultListener)
+        }
+    }
+
+    fun create() {
+        if (!isViewAdded) {
+            view = LayoutInflater.from(context).inflate(R.layout.item_floaing, null, false)
+            (view as FloatingView).setCallbacks(this)
+
+            nuguBtn = view.findViewById(R.id.floating_nugu_button)
+            voiceChrome = view.findViewById(R.id.floating_voice_chrome)
+            sttView = view.findViewById(R.id.floating_stt)
+        }
+    }
+
+    private fun showViewAndHideOthers(view: View) {
+        view.visibility = View.VISIBLE
+        val hideTargets = arrayListOf<View>()
+        when (view) {
+            nuguBtn -> {
+                sttView.text = null
+                hideTargets.add(sttView)
+                hideTargets.add(voiceChrome)
+            }
+            voiceChrome -> {
+                sttView.text = null
+                hideTargets.add(sttView)
+                hideTargets.add(nuguBtn)
+            }
+            sttView -> {
+                hideTargets.add(voiceChrome)
+                hideTargets.add(nuguBtn)
+            }
+        }
+
+        hideTargets.forEach { it.visibility = View.INVISIBLE }
+    }
+
+    fun createLayoutParams() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            layoutParams = WindowManager.LayoutParams(
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                        or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+                        or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN
+                        or WindowManager.LayoutParams.FLAG_LAYOUT_INSET_DECOR,
+                PixelFormat.TRANSLUCENT
+            )
+        } else {
+            layoutParams = WindowManager.LayoutParams(
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.TYPE_SYSTEM_ALERT,
+                (WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                        or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+                        or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN
+                        or WindowManager.LayoutParams.FLAG_LAYOUT_INSET_DECOR),
+                PixelFormat.TRANSLUCENT
+            )
+        }
+        layoutParams.gravity = Gravity.CENTER
+    }
+
+    private fun moveBy(dx: Int, dy: Int) {
+        if (isViewAdded) {
+
+            layoutParams.x += dx
+            layoutParams.y += dy
+
+            val dm = context.resources.displayMetrics
+            layoutParams.x = layoutParams.x.coerceAtLeast(-dm.widthPixels / 2 + getWidth() / 2)
+                .coerceAtMost(dm.widthPixels / 2 - getWidth() / 2)
+            layoutParams.y = layoutParams.y.coerceAtLeast(-dm.heightPixels / 2 + getHeight() / 2)
+                .coerceAtMost(dm.heightPixels / 2 - getHeight() / 2)
+
+            windowManager.updateViewLayout(view, layoutParams)
+        }
+    }
+
+    private fun getWidth(): Int = view.measuredWidth
+
+    private fun getHeight(): Int = view.measuredHeight
+
+    override fun onDrag(dx: Int, dy: Int) {
+        moveBy(dx, dy)
+    }
+
+    override fun onClick() {
+        if (nuguBtn.visibility == View.VISIBLE) {
+            ClientManager.getClient().asrAgent?.startRecognition()
+        } else if (ClientManager.speechRecognizerAggregator.isActive()) {
+            ClientManager.speechRecognizerAggregator.stopListening()
+        } else {
+            ClientManager.getClient().localStopTTS()
+        }
+    }
+
+    override fun onLongPress() {
+        startActivity()
+    }
+
+    private fun startActivity() {
+        try {
+            val contentIntent = PendingIntent.getActivity(
+                context,
+                9999,
+                Intent(context, MainActivity::class.java)
+                    .addFlags(
+                        Intent.FLAG_ACTIVITY_NEW_TASK
+                                or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                                or Intent.FLAG_ACTIVITY_NO_USER_ACTION
+                                or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+                    ),
+                //.putExtras(pushIntent),
+                PendingIntent.FLAG_ONE_SHOT
+            )
+
+            contentIntent.send()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/app/src/main/java/com/skt/nugu/sampleapp/service/floating/FloatingView.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/service/floating/FloatingView.kt
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skt.nugu.sampleapp.service.floating
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import android.widget.FrameLayout
+
+class FloatingView @JvmOverloads constructor(
+    context: Context,
+    attributeSet: AttributeSet? = null,
+    def: Int = 0
+) :
+    FrameLayout(context, attributeSet, def), View.OnTouchListener {
+
+    private var downRawX: Int = 0
+    private var downRawY: Int = 0
+    private var lastX: Int = 0
+    private var lastY: Int = 0
+    private lateinit var callbacks: Callbacks
+    private val gestureDetector = GestureDetector(context, GestureListener())
+
+    init {
+        setOnTouchListener(this)
+    }
+
+    fun setCallbacks(callbacks: Callbacks) {
+        this.callbacks = callbacks
+    }
+
+    override fun onTouch(view: View, motionEvent: MotionEvent): Boolean {
+        gestureDetector.onTouchEvent(motionEvent)
+
+        val action = motionEvent.action
+        val x = motionEvent.rawX.toInt()
+        val y = motionEvent.rawY.toInt()
+
+        when (action) {
+            MotionEvent.ACTION_DOWN -> {
+                downRawX = x
+                downRawY = y
+                lastX = x
+                lastY = y
+                return true // Consumed
+            }
+            MotionEvent.ACTION_MOVE -> {
+                val nx = (x - lastX)
+                val ny = (y - lastY)
+                lastX = x
+                lastY = y
+
+                callbacks.onDrag(nx, ny)
+                return true // Consumed
+            }
+
+            MotionEvent.ACTION_UP -> {
+                return true
+            }
+            else -> {
+                return super.onTouchEvent(motionEvent)
+            }
+        }
+    }
+
+    inner class GestureListener : GestureDetector.SimpleOnGestureListener() {
+        override fun onSingleTapUp(e: MotionEvent?): Boolean {
+            callbacks.onClick()
+            return true
+        }
+
+        override fun onLongPress(e: MotionEvent?) {
+            callbacks.onLongPress()
+        }
+    }
+
+    interface Callbacks {
+        fun onDrag(dx: Int, dy: Int) {}
+        fun onClick() {}
+        fun onLongPress() {}
+    }
+
+}
+

--- a/app/src/main/java/com/skt/nugu/sampleapp/service/floating/FlowTextView.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/service/floating/FlowTextView.kt
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2019 SK Telecom Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skt.nugu.sampleapp.service.floating
+
+import android.content.Context
+import android.util.AttributeSet
+
+/**
+ * Usage.
+ * when (according to change of text)
+ * textView's layout is changed -> invoke update() in onLayout()
+ * or not -> invoke update() in onTextChanged()
+ */
+
+class FlowTextView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyle: Int = 0) :
+    android.support.v7.widget.AppCompatTextView(context, attrs, defStyle) {
+    private fun updateText() {
+        if (lineCount > maxLines && !text.isNullOrBlank()) {
+            val enableLength = layout.getLineEnd(maxLines - 1)
+            val newText = text.substring(text.length - enableLength, text.length).trim()
+            text = newText
+        }
+    }
+
+    override fun onTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, lengthAfter: Int) {
+        super.onTextChanged(text, start, lengthBefore, lengthAfter)
+        updateText()
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+//        updateText()
+    }
+}

--- a/app/src/main/res/drawable-xhdpi/background_white_rect.xml
+++ b/app/src/main/res/drawable-xhdpi/background_white_rect.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@android:color/white"/>
+    <corners android:radius="15dp"/>
+</shape>

--- a/app/src/main/res/layout/item_floaing.xml
+++ b/app/src/main/res/layout/item_floaing.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.skt.nugu.sampleapp.service.floating.FloatingView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="70dp"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/floating_nugu_button"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_gravity="center"
+        android:background="@drawable/btn_blue_pressed"
+        android:padding="10dp"
+        android:src="@drawable/btn_blue_micicon" />
+
+    <com.skt.nugu.sdk.platform.android.ux.widget.NuguVoiceChromeView
+        android:id="@+id/floating_voice_chrome"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:padding="5dp"
+        android:background="@drawable/background_white_rect"
+        android:layout_gravity="center" />
+
+    <com.skt.nugu.sampleapp.service.floating.FlowTextView
+        android:id="@+id/floating_stt"
+        android:layout_width="70dp"
+        android:layout_height="50dp"
+        android:layout_gravity="center"
+        android:background="@drawable/background_white_rect"
+        android:includeFontPadding="false"
+        android:paddingHorizontal="1dp"
+        android:layout_margin="0dp"
+        android:maxLines="1"
+        android:gravity="center"
+        android:textColor="@android:color/black"
+        android:textSize="13sp"
+        android:visibility="invisible"
+        />
+
+</com.skt.nugu.sampleapp.service.floating.FloatingView>

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/TemplateView.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/TemplateView.kt
@@ -29,7 +29,7 @@ interface TemplateView {
 
         const val AUDIO_PLAYER_TEMPLATE_1 = "AudioPlayer.Template1"
         const val AUDIO_PLAYER_TEMPLATE_2 = "AudioPlayer.Template2"
-        val mediaTemplateTypes = listOf(AUDIO_PLAYER_TEMPLATE_1, AUDIO_PLAYER_TEMPLATE_2)
+        val MEDIA_TEMPLATE_TYPES = listOf(AUDIO_PLAYER_TEMPLATE_1, AUDIO_PLAYER_TEMPLATE_2)
 
         /**
          * key : TemplateType list
@@ -37,7 +37,7 @@ interface TemplateView {
          */
         val templateConstructor: HashMap<List<String>, (String, Context) -> TemplateView> by lazy {
             HashMap<List<String>, (String, Context) -> TemplateView>().also {
-                it[mediaTemplateTypes] = { templateType, context ->
+                it[MEDIA_TEMPLATE_TYPES] = { templateType, context ->
                     DisplayAudioPlayer(templateType, context)
                 }
             }
@@ -50,7 +50,7 @@ interface TemplateView {
          * @return appropriate TemplateView object which is determined by templateType
          */
         fun createView(templateType: String, context: Context, forceToWebView: Boolean = false): TemplateView {
-            Logger.i(TAG, "createView(). templateType: $templateType, native? ${mediaTemplateTypes.contains(templateType)}")
+            Logger.i(TAG, "createView(). templateType: $templateType, native? ${MEDIA_TEMPLATE_TYPES.contains(templateType)}")
 
             if (!forceToWebView) {
                 templateConstructor.keys.find { it.contains(templateType) }?.let { key ->

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/presenter/EmptyLyricsPresenter.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/presenter/EmptyLyricsPresenter.kt
@@ -1,0 +1,22 @@
+package com.skt.nugu.sdk.platform.android.ux.template.presenter
+
+import com.skt.nugu.sdk.agent.audioplayer.lyrics.LyricsPresenter
+import com.skt.nugu.sdk.agent.common.Direction
+
+object EmptyLyricsPresenter : LyricsPresenter {
+    override fun getVisibility(): Boolean {
+        return false
+    }
+
+    override fun show(): Boolean {
+        return false
+    }
+
+    override fun hide(): Boolean {
+        return false
+    }
+
+    override fun controlPage(direction: Direction): Boolean {
+        return false
+    }
+}

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/presenter/TemplateRenderer.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/presenter/TemplateRenderer.kt
@@ -6,19 +6,18 @@ import android.support.annotation.Keep
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import com.google.gson.Gson
-import com.skt.nugu.sdk.agent.audioplayer.lyrics.LyricsPresenter
-import com.skt.nugu.sdk.agent.common.Direction
 import com.skt.nugu.sdk.agent.display.DisplayAggregatorInterface
 import com.skt.nugu.sdk.core.interfaces.message.Header
 import com.skt.nugu.sdk.core.utils.Logger
 import com.skt.nugu.sdk.platform.android.NuguAndroidClient
 import org.json.JSONObject
+import java.lang.RuntimeException
 import java.lang.ref.WeakReference
 
 class TemplateRenderer(
     private val nuguClientProvider: NuguClientProvider,
     deviceTypeCode: String,
-    fragmentManager: FragmentManager,
+    fragmentManager: FragmentManager? = null,
     private val containerId: Int
 ) : DisplayAggregatorInterface.Renderer {
 
@@ -32,31 +31,34 @@ class TemplateRenderer(
         fun getNuguClient(): NuguAndroidClient
     }
 
-    private val fragmentManagerRef = WeakReference(fragmentManager)
+    /**
+     * The other Renderer that show any view associated with template.
+     * For example if you show media notification by play status independently, it needs to be inform to TemplateRenderer.
+     * Implement this interface and return templateId list being shown.
+     */
+    interface ExternalViewRenderer {
+        class ViewInfo(val templateId: String)
+
+        fun getVisibleList(): List<ViewInfo>?
+    }
+
+    private var fragmentManagerRef = WeakReference(fragmentManager)
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private val gson = Gson()
 
+    fun setFragmentManager(fragmentManager: FragmentManager?) {
+        fragmentManagerRef.clear()
+        fragmentManagerRef = WeakReference(fragmentManager)
+    }
+
+    var externalViewRenderer: ExternalViewRenderer? = null
+
     init {
         DEVICE_TYPE_CODE = deviceTypeCode
+
         //Empty lyrics presenter for receiving lyrics. Actual lyrics control works in each TemplateView.
-        nuguClientProvider.getNuguClient().audioPlayerAgent?.setLyricsPresenter(object : LyricsPresenter {
-            override fun getVisibility(): Boolean {
-                return false
-            }
-
-            override fun show(): Boolean {
-                return false
-            }
-
-            override fun hide(): Boolean {
-                return false
-            }
-
-            override fun controlPage(direction: Direction): Boolean {
-                return false
-            }
-        })
+        nuguClientProvider.getNuguClient().audioPlayerAgent?.setLyricsPresenter(EmptyLyricsPresenter)
     }
 
     @Keep
@@ -75,6 +77,11 @@ class TemplateRenderer(
             TAG,
             "render() templateId:$templateId, \n templateType:$templateType, \n templateContent:$templateContent, \n header:$header, \n displayType$displayType"
         )
+
+        if (fragmentManagerRef.get() == null) {
+            Logger.d(TAG, "render() return false; fragmentManager is null")
+            return false
+        }
 
         mainHandler.post {
             val templateContentWithType = insertType(templateContent, templateType)
@@ -108,6 +115,7 @@ class TemplateRenderer(
                             containerId,
                             TemplateFragment.newInstance(
                                 nuguProvider = nuguClientProvider,
+                                externalRenderer = externalViewRenderer,
                                 name = templateType,
                                 dialogRequestId = header.dialogRequestId,
                                 templateId = templateId,

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/presenter/TemplateViewModel.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/presenter/TemplateViewModel.kt
@@ -9,6 +9,7 @@ class TemplateViewModel : ViewModel() {
     }
 
     lateinit var nuguClientProvider: TemplateRenderer.NuguClientProvider
+    lateinit var externalRenderer: TemplateRenderer.ExternalViewRenderer
     var renderNotified = TemplateFragment.RenderNotifyState.NONE
     var onClose : (() -> Unit)? = null
 

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/view/media/DisplayAudioPlayer.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/view/media/DisplayAudioPlayer.kt
@@ -36,6 +36,7 @@ import com.skt.nugu.sdk.platform.android.ux.template.controller.TemplateHandler
 import com.skt.nugu.sdk.platform.android.ux.template.view.TemplateNativeView
 import com.skt.nugu.sdk.platform.android.ux.template.TemplateView
 import com.skt.nugu.sdk.platform.android.ux.template.model.*
+import com.skt.nugu.sdk.platform.android.ux.template.presenter.EmptyLyricsPresenter
 import com.skt.nugu.sdk.platform.android.ux.widget.NuguButton.Companion.dpToPx
 import com.skt.nugu.sdk.platform.android.ux.widget.setThrottledOnClickListener
 
@@ -434,7 +435,7 @@ constructor(private val templateType: String, context: Context, attrs: Attribute
 
         (templateHandler as? DefaultTemplateHandler)?.run {
             if (getNuguClient().audioPlayerAgent?.lyricsPresenter == lyricPresenter) {
-                getNuguClient().audioPlayerAgent?.setLyricsPresenter(null)
+                getNuguClient().audioPlayerAgent?.setLyricsPresenter(EmptyLyricsPresenter)
             }
         }
     }

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/webview/TemplateWebView.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/webview/TemplateWebView.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import android.graphics.Color
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
@@ -41,6 +40,7 @@ import java.net.URLEncoder
 import java.util.*
 import kotlin.concurrent.fixedRateTimer
 import com.skt.nugu.sdk.platform.android.ux.template.controller.DefaultTemplateHandler
+import com.skt.nugu.sdk.platform.android.ux.template.presenter.EmptyLyricsPresenter
 
 @SuppressLint("ClickableViewAccessibility")
 class TemplateWebView @JvmOverloads constructor(
@@ -207,6 +207,12 @@ class TemplateWebView @JvmOverloads constructor(
         super.onDetachedFromWindow()
         Logger.d(TAG, "onDetachedFromWindow")
         templateHandler?.clear()
+
+        (templateHandler as? DefaultTemplateHandler)?.run {
+            if (getNuguClient().audioPlayerAgent?.lyricsPresenter == lyricPresenter) {
+                getNuguClient().audioPlayerAgent?.setLyricsPresenter(EmptyLyricsPresenter)
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Add ExternalViewRenderer interface in TemplateRenderer and apply to SampleApp

case)
Basically TemplateRenderer has dependency with Fragment. 
So when user destroys activity during media template is viewing and media is playing, 
media goes to be stopped even it is expected to be play continue with notification.
So TemplateRenderer need to know the other view renderer.

plus) 
fix bug that lyrics not shown sometimes
