### PR TITLE
Improve gRPC connection for backoff and reconnect #1627

### DIFF
--- a/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/port/transport/grpc2/devicegateway/DeviceGatewayTransport.kt
+++ b/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/port/transport/grpc2/devicegateway/DeviceGatewayTransport.kt
@@ -34,6 +34,6 @@ interface DeviceGatewayTransport : Transport {
 
     fun onReceiveDirectives(directiveMessage: DirectiveMessage)
     fun onReceiveAttachment(attachmentMessage: AttachmentMessage)
-    fun onError(status: Status)
+    fun onError(status: Status, who: String)
     fun onPingRequestAcknowledged()
 }

--- a/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/port/transport/grpc2/devicegateway/EventsService.kt
+++ b/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/port/transport/grpc2/devicegateway/EventsService.kt
@@ -50,6 +50,7 @@ internal class EventsService(
 ) {
     companion object {
         private const val TAG = "EventsService"
+        val name = EventsService::class.java.simpleName
     }
 
     private val isShutdown = AtomicBoolean(false)
@@ -140,7 +141,7 @@ internal class EventsService(
                         }
                         if (it.checkIfDirectiveIsUnauthorizedRequestException()) {
                             call.onComplete(SDKStatus.UNAUTHENTICATED)
-                            observer.onError(Status.UNAUTHENTICATED)
+                            observer.onError(Status.UNAUTHENTICATED, name)
                         }
                     }
                 }
@@ -188,7 +189,7 @@ internal class EventsService(
                     }
                 }
                 Logger.e(TAG, log.toString())
-                observer.onError(status)
+                observer.onError(status, name)
             }
         }
 

--- a/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/port/transport/grpc2/devicegateway/PingService.kt
+++ b/nugu-client-kit/src/main/java/com/skt/nugu/sdk/client/port/transport/grpc2/devicegateway/PingService.kt
@@ -41,6 +41,7 @@ internal class PingService(
     private var blockingStub: VoiceServiceGrpc.VoiceServiceBlockingStub? = null
 
     companion object {
+        val name : String = PingService::class.java.simpleName
         private const val TAG = "PingService"
         private const val defaultInterval: Long = 1000 * 60L
         private const val defaultTimeout: Long = 1000 * 10L
@@ -55,7 +56,7 @@ internal class PingService(
         nextInterval(0)
     }
 
-    private fun executePingRequest() : Boolean{
+    private fun executePingRequest() : Boolean {
         try {
             if(blockingStub == null) {
                 blockingStub = VoiceServiceGrpc.newBlockingStub(channel)
@@ -73,7 +74,7 @@ internal class PingService(
             if (!isShutdown.get()) {
                 val status = Status.fromThrowable(e)
                 Logger.d(TAG, "[onError] ${status.code}, ${status.description}")
-                observer.onError(status)
+                observer.onError(status, name)
             }
         }
         return false
@@ -111,5 +112,10 @@ internal class PingService(
         } else {
             Logger.w(TAG, "[shutdown] already shutdown")
         }
+    }
+
+    fun newPing() {
+        intervalFuture?.cancel(true)
+        nextInterval(0)
     }
 }


### PR DESCRIPTION
- Rename eventMessageHeaders to pendingHeaders
- Rename handleConnectedIfNeeded to handleOnConnected
- Add 'who' parameter(onError) to check whether it is a PingService error or an EventsService error
- **Change from disconnect to channel.enterIdle() in onRetry**
  (https://github.com/grpc/grpc-java/issues/4056)