### PR TITLE
Fix AudioPlayer's focus not canceled #1729

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
@@ -1233,9 +1233,10 @@ class DefaultAudioPlayerAgent(
             }
         }
 
+        playDirectiveController.onPlayerStopped()
+
         handlePlaybackCompleted(true)
         stopReason = null
-        playDirectiveController.onPlayerStopped()
     }
 
     private fun executeOnPlaybackFinished(id: SourceId) {


### PR DESCRIPTION
before:
handlePlaybackCompleted()
->playSyncManager.release()
->at executor(onGranted())
->at executor(onPlaybackStopped())

after:
handlePlaybackCompleted()
->playSyncManager.release()
->at executor(onPlayerStopped())
-> atexecutor(onGranted())

onPlayerStopped() should be called before onGranted()

because, playDirectiveController's waitPlayExecuteInfo member should be
cleared, before onGranted called.