### PR TITLE
Apply delay to removing template to avoid exposure of rear screen very short.

### DIFF
--- a/nugu-ux-kit/src/main/res/layout-land/view_display_audioplayer.xml
+++ b/nugu-ux-kit/src/main/res/layout-land/view_display_audioplayer.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tool="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#f8f8f8">
+    android:layout_height="match_parent">
 
     <include layout="@layout/view_music_bar_player" />
 

--- a/nugu-ux-kit/src/main/res/layout/fragment_template.xml
+++ b/nugu-ux-kit/src/main/res/layout/fragment_template.xml
@@ -6,8 +6,7 @@
     <FrameLayout
         android:id="@+id/template_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/white" />
+        android:layout_height="match_parent" />
 
     <ImageView
         android:id="@+id/btn_bar_close"

--- a/nugu-ux-kit/src/main/res/layout/view_display_audioplayer.xml
+++ b/nugu-ux-kit/src/main/res/layout/view_display_audioplayer.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tool="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#f8f8f8">
+    android:layout_height="match_parent">
 
     <include layout="@layout/view_music_bar_player" />
 
@@ -12,6 +11,7 @@
         android:id="@+id/view_music_player"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="#f8f8f8"
         android:visibility="invisible">
 
         <FrameLayout
@@ -96,12 +96,12 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="2dp"
+                        android:ellipsize="end"
                         android:fontFamily="@font/noto_sans_kr_regular_hestia"
                         android:gravity="center"
                         android:maxLines="1"
                         android:minHeight="18dp"
                         android:padding="0dp"
-                        android:ellipsize="end"
                         android:textColor="#444444"
                         android:textSize="15sp"
                         android:visibility="gone" />

--- a/nugu-ux-kit/src/main/res/layout/view_music_bar_player.xml
+++ b/nugu-ux-kit/src/main/res/layout/view_music_bar_player.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="58dp"
     android:layout_gravity="bottom"
+    android:background="#f8f8f8"
     android:orientation="vertical">
 
     <FrameLayout


### PR DESCRIPTION
-Apply delay to removing template to avoid exposure of rear screen very short when transition occurs.
It is like a blink.

-Make media template background transparent to do not cover rear screen when it is collapsed mode.