### PR TITLE
Fix ExoMediaPlayer(Sample) cacheKey update order (COSTELTV-76)

### DIFF
--- a/app/src/main/java/com/skt/nugu/sampleapp/player/exo/ExoMediaPlayer.kt
+++ b/app/src/main/java/com/skt/nugu/sampleapp/player/exo/ExoMediaPlayer.kt
@@ -285,11 +285,10 @@ class ExoMediaPlayer(
         }
 
         lastPreparedUri = uri
+        lastPreparedCacheKey = cacheKey
         val uriStr = uri.toString()
         player.setMediaSource(buildMediaSource(Uri.parse(uriStr), cacheKey))
         player.prepare()
-
-        lastPreparedCacheKey = cacheKey
 
         return SourceId(sourceId.id + 1).also {
             sourceId = it


### PR DESCRIPTION
* Sometimes, player gets previous music stream from local cache.