### PR TITLE
Memory usage optimization

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/AbstractCapabilityAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/AbstractCapabilityAgent.kt
@@ -25,12 +25,9 @@ import com.skt.nugu.sdk.core.interfaces.context.SupportedInterfaceContextProvide
  * * should handle directives which provided
  * * should provide an capability context's state
  */
-abstract class AbstractCapabilityAgent(private val interfaceName: String) : CapabilityAgent
+abstract class AbstractCapabilityAgent(interfaceName: String) : CapabilityAgent
     , AbstractDirectiveHandler()
     , SupportedInterfaceContextProvider {
 
-    final override val namespaceAndName: NamespaceAndName
-        get() = super.namespaceAndName
-
-    override fun getInterfaceName(): String = interfaceName
+    final override val namespaceAndName: NamespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, interfaceName)
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultASRAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultASRAgent.kt
@@ -816,16 +816,12 @@ class DefaultASRAgent(
         }
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[EXPECT_SPEECH] = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[EXPECT_SPEECH] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-        configuration[NOTIFY_RESULT] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+        this[NOTIFY_RESULT] = BlockingPolicy.sharedInstanceFactory.get()
     }
 
     override fun addOnStateChangeListener(listener: ASRAgentInterface.OnStateChangeListener) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
@@ -154,6 +154,8 @@ class DefaultAudioPlayerAgent(
         INTERNAL_LOGIC,
     }
 
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
+
     private val lifeCycleScheduler: LifeCycleScheduler? =
         if (enableDisplayLifeCycleManagement) LifeCycleScheduler() else null
 
@@ -719,8 +721,6 @@ class DefaultAudioPlayerAgent(
             directiveSequencer.addDirectiveHandler(this)
         }
     }
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     private fun notifyOnReleaseAudioInfo(info: AudioInfo, immediately: Boolean) {
         Logger.d(TAG, "[notifyOnReleaseAudioInfo] $info")

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultBluetoothAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultBluetoothAgent.kt
@@ -289,18 +289,16 @@ class DefaultBluetoothAgent(
         @SerializedName("playServiceId") val playServiceId: String
     )
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
         val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
 
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-        configuration[START_DISCOVERABLE_MODE] = nonBlockingPolicy
-        configuration[FINISH_DISCOVERABLE_MODE] = nonBlockingPolicy
-        configuration[PLAY] = nonBlockingPolicy
-        configuration[STOP] = nonBlockingPolicy
-        configuration[PAUSE] = nonBlockingPolicy
-        configuration[NEXT] = nonBlockingPolicy
-        configuration[PREVIOUS] = nonBlockingPolicy
-        return configuration
+        this[START_DISCOVERABLE_MODE] = nonBlockingPolicy
+        this[FINISH_DISCOVERABLE_MODE] = nonBlockingPolicy
+        this[PLAY] = nonBlockingPolicy
+        this[STOP] = nonBlockingPolicy
+        this[PAUSE] = nonBlockingPolicy
+        this[NEXT] = nonBlockingPolicy
+        this[PREVIOUS] = nonBlockingPolicy
     }
 
     override fun provideState(

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultDelegationAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultDelegationAgent.kt
@@ -123,14 +123,8 @@ class DefaultDelegationAgent(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[DELEGATE] = nonBlockingPolicy
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[DELEGATE] = BlockingPolicy.sharedInstanceFactory.get()
     }
 
     internal data class StateContext(private val appContext: DelegationClient.Context?): BaseContextState {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultExtensionAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultExtensionAgent.kt
@@ -175,14 +175,8 @@ class DefaultExtensionAgent(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[ACTION] = nonBlockingPolicy
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[ACTION] = BlockingPolicy.sharedInstanceFactory.get()
     }
 
     private fun sendActionEvent(name: String, playServiceId: String, referrerDialogRequestId: String) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultMicrophoneAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultMicrophoneAgent.kt
@@ -24,9 +24,7 @@ import com.skt.nugu.sdk.agent.version.Version
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.*
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 import com.skt.nugu.sdk.core.utils.Logger
 import java.util.*
@@ -186,14 +184,8 @@ class DefaultMicrophoneAgent(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[SET_MIC] = nonBlockingPolicy
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[SET_MIC] = BlockingPolicy.sharedInstanceFactory.get()
     }
 
     override fun provideState(

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultScreenAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultScreenAgent.kt
@@ -24,9 +24,7 @@ import com.skt.nugu.sdk.agent.version.Version
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.*
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 import com.skt.nugu.sdk.core.utils.Logger
 import java.util.concurrent.Executors
@@ -167,16 +165,11 @@ class DefaultScreenAgent(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
         val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[TURN_ON] = nonBlockingPolicy
-        configuration[TURN_OFF] = nonBlockingPolicy
-        configuration[SET_BRIGHTNESS] = nonBlockingPolicy
-
-        return configuration
+        this[TURN_ON] = nonBlockingPolicy
+        this[TURN_OFF] = nonBlockingPolicy
+        this[SET_BRIGHTNESS] = nonBlockingPolicy
     }
 
     internal data class StateContext(val settings: Screen.Settings): BaseContextState {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultSpeakerAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultSpeakerAgent.kt
@@ -18,20 +18,18 @@ package com.skt.nugu.sdk.agent
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.annotations.SerializedName
-import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.agent.speaker.Speaker
 import com.skt.nugu.sdk.agent.speaker.SpeakerManagerInterface
 import com.skt.nugu.sdk.agent.speaker.SpeakerManagerObserver
 import com.skt.nugu.sdk.agent.util.IgnoreErrorContextRequestor
 import com.skt.nugu.sdk.agent.util.MessageFactory
 import com.skt.nugu.sdk.agent.version.Version
+import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.*
-import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.utils.Logger
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
-import com.skt.nugu.sdk.core.interfaces.message.Status
+import com.skt.nugu.sdk.core.interfaces.message.MessageSender
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
+import com.skt.nugu.sdk.core.utils.Logger
 import java.util.concurrent.Executors
 
 class DefaultSpeakerAgent(
@@ -291,18 +289,14 @@ class DefaultSpeakerAgent(
         info.result.setFailed(msg)
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
         val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
 
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[SET_VOLUME] = nonBlockingPolicy
-        configuration[SET_MUTE] = nonBlockingPolicy
-
-        return configuration
+        this[SET_VOLUME] = nonBlockingPolicy
+        this[SET_MUTE] = nonBlockingPolicy
     }
 
     data class SpeakerContext(

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultSystemAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultSystemAgent.kt
@@ -29,15 +29,11 @@ import com.skt.nugu.sdk.core.interfaces.connection.ConnectionManagerInterface
 import com.skt.nugu.sdk.core.interfaces.context.*
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.directive.DirectiveSequencerInterface
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 import com.skt.nugu.sdk.core.utils.Logger
 import java.util.*
 import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
 import kotlin.collections.HashMap
 
 class DefaultSystemAgent(
@@ -174,19 +170,17 @@ class DefaultSystemAgent(
         onUserDisconnect()
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
         val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
 
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-        configuration[HANDOFF_CONNECTION] = nonBlockingPolicy
-        configuration[TURN_OFF] = nonBlockingPolicy
-        configuration[UPDATE_STATE] = nonBlockingPolicy
-        configuration[EXCEPTION] = nonBlockingPolicy
-        configuration[ECHO] = nonBlockingPolicy
-        configuration[NO_DIRECTIVES] = nonBlockingPolicy
-        configuration[NOOP] = nonBlockingPolicy
-        configuration[RESET_CONNECTION] = nonBlockingPolicy
-        return configuration
+        this[HANDOFF_CONNECTION] = nonBlockingPolicy
+        this[TURN_OFF] = nonBlockingPolicy
+        this[UPDATE_STATE] = nonBlockingPolicy
+        this[EXCEPTION] = nonBlockingPolicy
+        this[ECHO] = nonBlockingPolicy
+        this[NO_DIRECTIVES] = nonBlockingPolicy
+        this[NOOP] = nonBlockingPolicy
+        this[RESET_CONNECTION] = nonBlockingPolicy
     }
 
     override fun preHandleDirective(info: DirectiveInfo) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultTTSAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultTTSAgent.kt
@@ -95,7 +95,6 @@ class DefaultTTSAgent(
             NAME_SPEAK
         )
 
-
         private const val EVENT_SPEECH_STARTED = "SpeechStarted"
         private const val EVENT_SPEECH_FINISHED = "SpeechFinished"
         private const val EVENT_SPEECH_STOPPED = "SpeechStopped"
@@ -649,15 +648,11 @@ class DefaultTTSAgent(
         return SpeakDirectiveInfo(info, payload)
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[SPEAK] = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[SPEAK] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-
-        return configuration
     }
 
     private fun executeReleaseSync(info: SpeakDirectiveInfo) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/CancelRecognizeDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/CancelRecognizeDirectiveHandler.kt
@@ -22,7 +22,7 @@ import com.skt.nugu.sdk.agent.DefaultASRAgent
 import com.skt.nugu.sdk.agent.util.MessageFactory
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import java.util.HashMap
+import java.util.*
 
 class CancelRecognizeDirectiveHandler(
     private val agent: ASRAgentInterface
@@ -69,11 +69,7 @@ class CancelRecognizeDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[NOTIFY_RESULT] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[NOTIFY_RESULT] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/lyrics/AudioPlayerLyricsDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/lyrics/AudioPlayerLyricsDirectiveHandler.kt
@@ -28,9 +28,7 @@ import com.skt.nugu.sdk.core.interfaces.context.ContextManagerInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.display.InterLayerDisplayPolicyManager
 import com.skt.nugu.sdk.core.interfaces.display.LayerType
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 import com.skt.nugu.sdk.core.utils.Logger
 
@@ -44,10 +42,8 @@ class AudioPlayerLyricsDirectiveHandler(
     companion object {
         private const val TAG = "AudioPlayerLyricsDirectiveHandler"
 
-        private const val NAMESPACE =
-            DefaultAudioPlayerAgent.NAMESPACE
-        private val VERSION =
-            DefaultAudioPlayerAgent.VERSION
+        private const val NAMESPACE = DefaultAudioPlayerAgent.NAMESPACE
+        private val VERSION = DefaultAudioPlayerAgent.VERSION
 
         // v1.1
         private const val NAME_SHOW_LYRICS = "ShowLyrics"
@@ -100,6 +96,8 @@ class AudioPlayerLyricsDirectiveHandler(
         @SerializedName("playStackControl")
         val playStackControl: PlayStackControl?
     )
+
+   private val audioPlayerNamespaceAndName = NamespaceAndName("supportedInterfaces", NAMESPACE)
 
     override fun preHandleDirective(info: DirectiveInfo) {
         // no-op
@@ -184,7 +182,7 @@ class AudioPlayerLyricsDirectiveHandler(
                         .build()
                 ).enqueue(null)
             }
-        }, NamespaceAndName("supportedInterfaces", NAMESPACE))
+        },audioPlayerNamespaceAndName)
     }
 
     private fun sendPageControlEvent(name: String, playServiceId: String, direction: Direction, referrerDialogRequestId: String) {
@@ -202,21 +200,17 @@ class AudioPlayerLyricsDirectiveHandler(
                         .build()
                 ).enqueue(null)
             }
-        }, NamespaceAndName("supportedInterfaces", NAMESPACE))
+        }, audioPlayerNamespaceAndName)
     }
 
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
         val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[SHOW_LYRICS] = nonBlockingPolicy
-        configuration[HIDE_LYRICS] = nonBlockingPolicy
-        configuration[CONTROL_LYRICS_PAGE] = nonBlockingPolicy
-
-        return configuration
+        this[SHOW_LYRICS] = nonBlockingPolicy
+        this[HIDE_LYRICS] = nonBlockingPolicy
+        this[CONTROL_LYRICS_PAGE] = nonBlockingPolicy
     }
 
     private fun setHandlingFailed(info: DirectiveInfo, msg: String) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/metadata/AudioPlayerMetadataDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/metadata/AudioPlayerMetadataDirectiveHandler.kt
@@ -53,13 +53,7 @@ class AudioPlayerMetadataDirectiveHandler: AbstractDirectiveHandler() {
         val metadata: JsonObject
     )
 
-    private val supportConfigurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
     private val listeners = CopyOnWriteArraySet<Listener>()
-
-    init {
-        supportConfigurations[UPDATE_METADATA] = BlockingPolicy.sharedInstanceFactory.get()
-    }
 
     override fun preHandleDirective(info: DirectiveInfo) {
         // nothing to do
@@ -85,7 +79,9 @@ class AudioPlayerMetadataDirectiveHandler: AbstractDirectiveHandler() {
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> = supportConfigurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[UPDATE_METADATA] = BlockingPolicy.sharedInstanceFactory.get()
+    }
 
     fun addListener(listener: Listener) {
         listeners.add(listener)

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/playback/AudioPlayerRequestPlayCommandDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/playback/AudioPlayerRequestPlayCommandDirectiveHandler.kt
@@ -23,9 +23,7 @@ import com.skt.nugu.sdk.agent.util.IgnoreErrorContextRequestor
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class AudioPlayerRequestPlayCommandDirectiveHandler(
@@ -77,13 +75,8 @@ class AudioPlayerRequestPlayCommandDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-        val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
-
-        configurations[REQUEST_PLAY_COMMAND] = nonBlockingPolicy
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[REQUEST_PLAY_COMMAND] = BlockingPolicy.sharedInstanceFactory.get()
     }
 
     fun setRequestCommandHandler(handler: AudioPlayerAgentInterface.RequestCommandHandler) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/playback/AudioPlayerRequestPlaybackCommandDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/playback/AudioPlayerRequestPlaybackCommandDirectiveHandler.kt
@@ -9,9 +9,7 @@ import com.skt.nugu.sdk.agent.util.IgnoreErrorContextRequestor
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class AudioPlayerRequestPlaybackCommandDirectiveHandler(
@@ -138,17 +136,14 @@ class AudioPlayerRequestPlaybackCommandDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
         val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
 
-        configurations[REQUEST_RESUME_COMMAND] = nonBlockingPolicy
-        configurations[REQUEST_NEXT_COMMAND] = nonBlockingPolicy
-        configurations[REQUEST_PREVIOUS_COMMAND] = nonBlockingPolicy
-        configurations[REQUEST_PAUSE_COMMAND] = nonBlockingPolicy
-        configurations[REQUEST_STOP_COMMAND] = nonBlockingPolicy
-
-        return configurations
+        this[REQUEST_RESUME_COMMAND] = nonBlockingPolicy
+        this[REQUEST_NEXT_COMMAND] = nonBlockingPolicy
+        this[REQUEST_PREVIOUS_COMMAND] = nonBlockingPolicy
+        this[REQUEST_PAUSE_COMMAND] = nonBlockingPolicy
+        this[REQUEST_STOP_COMMAND] = nonBlockingPolicy
     }
 
     fun setRequestCommandHandler(handler: AudioPlayerAgentInterface.RequestCommandHandler) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/playback/PlaybackDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/audioplayer/playback/PlaybackDirectiveHandler.kt
@@ -48,8 +48,8 @@ class PlaybackDirectiveHandler(
         controller.onCancel(info.directive)
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
-        put(configuration.first, configuration.second)
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[configuration.first] = configuration.second
     }
 
     override fun onPostProcessed(directives: List<Directive>) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/battery/DefaultBatteryAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/battery/DefaultBatteryAgent.kt
@@ -33,11 +33,11 @@ class DefaultBatteryAgent(
         private val VERSION = Version(1,1)
     }
 
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
+
     init {
         contextStateProviderRegistry.setStateProvider(namespaceAndName, this)
     }
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     internal data class StateContext(
         val level: Int,

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/chips/ChipsAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/chips/ChipsAgent.kt
@@ -53,12 +53,12 @@ class ChipsAgent(
         override fun value(): String = COMPACT_STATE
     }
 
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
+
     init {
         contextStateProviderRegistry.setStateProvider(namespaceAndName, this)
         directiveSequencer.addDirectiveHandler(RenderDirectiveHandler(this, directiveSequencer, sessionManager))
     }
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     override fun provideState(
         contextSetter: ContextSetterInterface,

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/chips/handler/RenderDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/chips/handler/RenderDirectiveHandler.kt
@@ -147,13 +147,9 @@ class RenderDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[RENDER] = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[RENDER] = BlockingPolicy.sharedInstanceFactory.get(
             blocking = BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-
-        return configuration
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/AudioPlayerTemplateHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/AudioPlayerTemplateHandler.kt
@@ -419,18 +419,14 @@ class AudioPlayerTemplateHandler(
         this.renderer = renderer
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply{
         val blockingPolicy = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
 
-        val configuration = java.util.HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[AUDIOPLAYER_TEMPLATE1] = blockingPolicy
-        configuration[AUDIOPLAYER_TEMPLATE2] = blockingPolicy
-
-        return configuration
+        this[AUDIOPLAYER_TEMPLATE1] = blockingPolicy
+        this[AUDIOPLAYER_TEMPLATE2] = blockingPolicy
     }
 
     override fun onMetadataUpdate(playServiceId: String, jsonMetaData: String) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/CloseDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/CloseDirectiveHandler.kt
@@ -24,9 +24,7 @@ import com.skt.nugu.sdk.agent.util.MessageFactory
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 import com.skt.nugu.sdk.core.utils.Logger
 
@@ -63,6 +61,8 @@ class CloseDirectiveHandler(
         }
     }
 
+    private val displayNamespaceAndName = NamespaceAndName("supportedInterfaces", DisplayAgent.NAMESPACE)
+
     override fun preHandleDirective(info: DirectiveInfo) {
         // no-op
     }
@@ -98,17 +98,11 @@ class CloseDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val blockingPolicy = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[CLOSE] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[CLOSE] = blockingPolicy
-
-        return configuration
     }
 
     private fun sendCloseEvent(eventName: String, info: DirectiveInfo, playServiceId: String) {
@@ -127,10 +121,7 @@ class CloseDirectiveHandler(
                         .build()
                 ).enqueue(null)
             }
-        }, NamespaceAndName(
-            "supportedInterfaces",
-            DisplayAgent.NAMESPACE
-        ))
+        }, displayNamespaceAndName)
     }
 
     private fun sendCloseSucceeded(info: DirectiveInfo, playServiceId: String) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/ControlFocusDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/ControlFocusDirectiveHandler.kt
@@ -23,9 +23,7 @@ import com.skt.nugu.sdk.agent.util.MessageFactory
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 import com.skt.nugu.sdk.core.utils.Logger
 
@@ -120,16 +118,10 @@ class ControlFocusDirectiveHandler(
         }, namespaceAndName)
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val blockingPolicy = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[CONTROL_FOCUS] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[CONTROL_FOCUS] = blockingPolicy
-
-        return configuration
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/ControlScrollDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/ControlScrollDirectiveHandler.kt
@@ -162,16 +162,10 @@ class ControlScrollDirectiveHandler(
         }, namespaceAndName)
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val blockingPolicy = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[CONTROL_SCROLL] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[CONTROL_SCROLL] = blockingPolicy
-
-        return configuration
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/DisplayAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/DisplayAgent.kt
@@ -242,6 +242,8 @@ class DisplayAgent(
 
     private val listeners = LinkedHashSet<DisplayAgentInterface.Listener>()
 
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
+
     init {
         contextStateProviderRegistry.setStateProvider(namespaceAndName, this)
         contextLayerTimer?.apply {
@@ -250,8 +252,6 @@ class DisplayAgent(
             }
         }
     }
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     private fun executePreparePendingInfo(info: AbstractDirectiveHandler.DirectiveInfo, payload: TemplatePayload) {
         TemplateDirectiveInfo(info, payload).apply {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/RedirectTriggerChildDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/RedirectTriggerChildDirectiveHandler.kt
@@ -88,7 +88,7 @@ class RedirectTriggerChildDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> = mapOf(
-        Pair(REDIRECT_TRIGGER_CHILD, BlockingPolicy.sharedInstanceFactory.get())
-    )
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[REDIRECT_TRIGGER_CHILD] = BlockingPolicy.sharedInstanceFactory.get()
+    }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/RenderDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/RenderDirectiveHandler.kt
@@ -307,61 +307,56 @@ class RenderDirectiveHandler(
         controller.cancelRender(info.directive.getMessageId())
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
         val blockingPolicy = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
+        this[FULLTEXT1] = blockingPolicy
+        this[FULLTEXT2] = blockingPolicy
+        this[FULLTEXT3] = blockingPolicy
+        this[IMAGETEXT1] = blockingPolicy
+        this[IMAGETEXT2] = blockingPolicy
+        this[IMAGETEXT3] = blockingPolicy
+        this[IMAGETEXT4] = blockingPolicy
+        this[IMAGETEXT5] = blockingPolicy
+        this[TEXTLIST1] = blockingPolicy
+        this[TEXTLIST2] = blockingPolicy
+        this[TEXTLIST3] = blockingPolicy
+        this[TEXTLIST4] = blockingPolicy
+        this[IMAGELIST1] = blockingPolicy
+        this[IMAGELIST2] = blockingPolicy
+        this[IMAGELIST3] = blockingPolicy
+        this[CUSTOM_TEMPLATE] = blockingPolicy
 
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
+        this[WEATHER1] = blockingPolicy
+        this[WEATHER2] = blockingPolicy
+        this[WEATHER3] = blockingPolicy
+        this[WEATHER4] = blockingPolicy
+        this[WEATHER5] = blockingPolicy
+        this[FULLIMAGE] = blockingPolicy
 
-        configuration[FULLTEXT1] = blockingPolicy
-        configuration[FULLTEXT2] = blockingPolicy
-        configuration[FULLTEXT3] = blockingPolicy
-        configuration[IMAGETEXT1] = blockingPolicy
-        configuration[IMAGETEXT2] = blockingPolicy
-        configuration[IMAGETEXT3] = blockingPolicy
-        configuration[IMAGETEXT4] = blockingPolicy
-        configuration[IMAGETEXT5] = blockingPolicy
-        configuration[TEXTLIST1] = blockingPolicy
-        configuration[TEXTLIST2] = blockingPolicy
-        configuration[TEXTLIST3] = blockingPolicy
-        configuration[TEXTLIST4] = blockingPolicy
-        configuration[IMAGELIST1] = blockingPolicy
-        configuration[IMAGELIST2] = blockingPolicy
-        configuration[IMAGELIST3] = blockingPolicy
-        configuration[CUSTOM_TEMPLATE] = blockingPolicy
+        this[SCORE_1] = blockingPolicy
+        this[SCORE_2] = blockingPolicy
+        this[SEARCH_LIST_1] = blockingPolicy
+        this[SEARCH_LIST_2] = blockingPolicy
 
-        configuration[WEATHER1] = blockingPolicy
-        configuration[WEATHER2] = blockingPolicy
-        configuration[WEATHER3] = blockingPolicy
-        configuration[WEATHER4] = blockingPolicy
-        configuration[WEATHER5] = blockingPolicy
-        configuration[FULLIMAGE] = blockingPolicy
+        this[COMMERCE_LIST] = blockingPolicy
+        this[COMMERCE_OPTION] = blockingPolicy
+        this[COMMERCE_PRICE] = blockingPolicy
+        this[COMMERCE_INFO] = blockingPolicy
 
-        configuration[SCORE_1] = blockingPolicy
-        configuration[SCORE_2] = blockingPolicy
-        configuration[SEARCH_LIST_1] = blockingPolicy
-        configuration[SEARCH_LIST_2] = blockingPolicy
+        this[CALL_1] = blockingPolicy
+        this[CALL_2] = blockingPolicy
+        this[CALL_3] = blockingPolicy
 
-        configuration[COMMERCE_LIST] = blockingPolicy
-        configuration[COMMERCE_OPTION] = blockingPolicy
-        configuration[COMMERCE_PRICE] = blockingPolicy
-        configuration[COMMERCE_INFO] = blockingPolicy
+        this[TIMER] = blockingPolicy
 
-        configuration[CALL_1] = blockingPolicy
-        configuration[CALL_2] = blockingPolicy
-        configuration[CALL_3] = blockingPolicy
+        this[DUMMY] = blockingPolicy
 
-        configuration[TIMER] = blockingPolicy
+        this[UNIFIED_SEARCH1] = blockingPolicy
 
-        configuration[DUMMY] = blockingPolicy
-
-        configuration[UNIFIED_SEARCH1] = blockingPolicy
-
-        configuration[TAB_EXTENSION] = blockingPolicy
-
-        return configuration
+        this[TAB_EXTENSION] = blockingPolicy
     }
 
     private fun setHandlingFailed(info: DirectiveInfo, description: String) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/UpdateDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/display/UpdateDirectiveHandler.kt
@@ -86,16 +86,10 @@ class UpdateDirectiveHandler(
         info.result.setCompleted()
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val blockingPolicy = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[UPDATE] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[UPDATE] = blockingPolicy
-
-        return configuration
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/MediaPlayerAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/MediaPlayerAgent.kt
@@ -18,7 +18,6 @@ package com.skt.nugu.sdk.agent.ext.mediaplayer
 
 import com.google.gson.JsonObject
 import com.skt.nugu.sdk.agent.ext.mediaplayer.event.*
-import com.skt.nugu.sdk.agent.ext.mediaplayer.event.EventCallback
 import com.skt.nugu.sdk.agent.ext.mediaplayer.handler.*
 import com.skt.nugu.sdk.agent.ext.mediaplayer.payload.*
 import com.skt.nugu.sdk.agent.version.Version
@@ -59,6 +58,8 @@ class MediaPlayerAgent(
         const val NAMESPACE = "MediaPlayer"
         val VERSION = Version(1, 1)
     }
+
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
 
     init {
         contextStateProviderRegistry.setStateProvider(namespaceAndName, this)
@@ -160,8 +161,6 @@ class MediaPlayerAgent(
     }
 
     private val executor = Executors.newSingleThreadExecutor()
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     internal data class StateContext(val context: Context): BaseContextState {
         companion object {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/GetInfoDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/GetInfoDirectiveHandler.kt
@@ -2,7 +2,6 @@ package com.skt.nugu.sdk.agent.ext.mediaplayer.handler
 
 import com.google.gson.JsonObject
 import com.skt.nugu.sdk.agent.AbstractDirectiveHandler
-import com.skt.nugu.sdk.agent.ext.mediaplayer.event.EventCallback
 import com.skt.nugu.sdk.agent.ext.mediaplayer.MediaPlayerAgent
 import com.skt.nugu.sdk.agent.ext.mediaplayer.Song
 import com.skt.nugu.sdk.agent.ext.mediaplayer.event.GetInfoCallback
@@ -13,9 +12,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class GetInfoDirectiveHandler(
@@ -113,11 +110,7 @@ class GetInfoDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[GET_INFO] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[GET_INFO] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/HandleLyricsDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/HandleLyricsDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class HandleLyricsDirectiveHandler(
@@ -109,11 +107,7 @@ class HandleLyricsDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[HANDLE_LYRICS] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[HANDLE_LYRICS] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/HandlePlaylistDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/HandlePlaylistDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class HandlePlaylistDirectiveHandler(
@@ -109,11 +107,7 @@ class HandlePlaylistDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[HANDLE_PLAYLIST] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[HANDLE_PLAYLIST] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/MoveDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/MoveDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class MoveDirectiveHandler(
@@ -110,11 +108,7 @@ class MoveDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[MOVE] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[MOVE] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/NextDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/NextDirectiveHandler.kt
@@ -17,9 +17,7 @@
 package com.skt.nugu.sdk.agent.ext.mediaplayer.handler
 
 import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import com.skt.nugu.sdk.agent.AbstractDirectiveHandler
-import com.skt.nugu.sdk.agent.ext.mediaplayer.event.EventCallback
 import com.skt.nugu.sdk.agent.ext.mediaplayer.MediaPlayerAgent
 import com.skt.nugu.sdk.agent.ext.mediaplayer.Playlist
 import com.skt.nugu.sdk.agent.ext.mediaplayer.Song
@@ -31,9 +29,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class NextDirectiveHandler(
@@ -150,11 +146,7 @@ class NextDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[NEXT] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[NEXT] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/PauseDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/PauseDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class PauseDirectiveHandler(
@@ -110,11 +108,7 @@ class PauseDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[PAUSE] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[PAUSE] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/PlayDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/PlayDirectiveHandler.kt
@@ -29,9 +29,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class PlayDirectiveHandler(
@@ -148,11 +146,7 @@ class PlayDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[PLAY] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[PLAY] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/PreviousDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/PreviousDirectiveHandler.kt
@@ -17,9 +17,7 @@
 package com.skt.nugu.sdk.agent.ext.mediaplayer.handler
 
 import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import com.skt.nugu.sdk.agent.AbstractDirectiveHandler
-import com.skt.nugu.sdk.agent.ext.mediaplayer.event.EventCallback
 import com.skt.nugu.sdk.agent.ext.mediaplayer.MediaPlayerAgent
 import com.skt.nugu.sdk.agent.ext.mediaplayer.Playlist
 import com.skt.nugu.sdk.agent.ext.mediaplayer.Song
@@ -31,9 +29,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class PreviousDirectiveHandler(
@@ -150,11 +146,7 @@ class PreviousDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[PREVIOUS] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[PREVIOUS] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/ResumeDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/ResumeDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class ResumeDirectiveHandler(
@@ -110,11 +108,7 @@ class ResumeDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[RESUME] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[RESUME] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/RewindDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/RewindDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class RewindDirectiveHandler(
@@ -110,11 +108,7 @@ class RewindDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[REWIND] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[REWIND] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/SearchDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/SearchDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class SearchDirectiveHandler (
@@ -111,11 +109,7 @@ class SearchDirectiveHandler (
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[SEARCH] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[SEARCH] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/StopDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/StopDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class StopDirectiveHandler(
@@ -110,11 +108,7 @@ class StopDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[PAUSE] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[PAUSE] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/ToggleDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/mediaplayer/handler/ToggleDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.message.Header
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class ToggleDirectiveHandler (
@@ -110,11 +108,7 @@ class ToggleDirectiveHandler (
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[TOGGLE] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[TOGGLE] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/MessageAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/MessageAgent.kt
@@ -60,7 +60,7 @@ class MessageAgent(
         val VERSION = Version(1, 5)
     }
 
-    override fun getInterfaceName(): String = NAMESPACE
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
 
     private val listeners = LinkedHashSet<MessageAgentInterface.OnPlaybackListener>()
     private val executor = Executors.newSingleThreadExecutor()

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/handler/GetMessageDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/handler/GetMessageDirectiveHandler.kt
@@ -166,11 +166,7 @@ class GetMessageDirectiveHandler (
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[GET_MESSAGE] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[GET_MESSAGE] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/handler/ReadMessageDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/handler/ReadMessageDirectiveHandler.kt
@@ -27,9 +27,7 @@ import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
 import com.skt.nugu.sdk.core.interfaces.directive.DirectiveHandlerResult
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 import com.skt.nugu.sdk.core.utils.Logger
 
@@ -121,14 +119,10 @@ class ReadMessageDirectiveHandler(
         controller.cancel(info.directive.getMessageId())
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[READ_MESSAGE] = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[READ_MESSAGE] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-
-        return configuration
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/handler/SendCandidatesDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/handler/SendCandidatesDirectiveHandler.kt
@@ -147,11 +147,7 @@ class SendCandidatesDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[SEND_CANDIDATES] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[SEND_CANDIDATES] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/handler/SendMessageDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/message/handler/SendMessageDirectiveHandler.kt
@@ -21,15 +21,12 @@ import com.skt.nugu.sdk.agent.AbstractDirectiveHandler
 import com.skt.nugu.sdk.agent.ext.message.EventCallback
 import com.skt.nugu.sdk.agent.ext.message.MessageAgent
 import com.skt.nugu.sdk.agent.ext.message.payload.SendMessagePayload
-import com.skt.nugu.sdk.agent.ext.phonecall.PhoneCallAgent
 import com.skt.nugu.sdk.agent.util.IgnoreErrorContextRequestor
 import com.skt.nugu.sdk.agent.util.MessageFactory
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class SendMessageDirectiveHandler(
@@ -106,11 +103,7 @@ class SendMessageDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[SEND_MESSAGE] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[SEND_MESSAGE] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/PhoneCallAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/PhoneCallAgent.kt
@@ -29,9 +29,7 @@ import com.skt.nugu.sdk.core.interfaces.focus.ChannelObserver
 import com.skt.nugu.sdk.core.interfaces.focus.FocusManagerInterface
 import com.skt.nugu.sdk.core.interfaces.focus.FocusState
 import com.skt.nugu.sdk.core.interfaces.interaction.InteractionControlManagerInterface
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 import com.skt.nugu.sdk.core.utils.Logger
 import java.util.concurrent.Callable
@@ -69,7 +67,7 @@ class PhoneCallAgent(
         private const val NAME_CALL_ESTABLISHED = "CallEstablished"
     }
 
-    override fun getInterfaceName(): String = NAMESPACE
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
 
     private val executor = Executors.newSingleThreadExecutor()
     private var state = State.IDLE

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/AcceptCallDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/AcceptCallDirectiveHandler.kt
@@ -53,11 +53,7 @@ class AcceptCallDirectiveHandler (
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[ACCEPT_CALL] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[ACCEPT_CALL] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/BlockIncomingCallDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/BlockIncomingCallDirectiveHandler.kt
@@ -53,11 +53,7 @@ class BlockIncomingCallDirectiveHandler (
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[BLOCK_INCOMING_CALL] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[BLOCK_INCOMING_CALL] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/EndCallDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/EndCallDirectiveHandler.kt
@@ -53,11 +53,7 @@ class EndCallDirectiveHandler (
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[END_CALL] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[END_CALL] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/MakeCallDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/MakeCallDirectiveHandler.kt
@@ -25,9 +25,7 @@ import com.skt.nugu.sdk.agent.util.MessageFactory
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
 import com.skt.nugu.sdk.core.interfaces.directive.BlockingPolicy
-import com.skt.nugu.sdk.core.interfaces.message.MessageRequest
 import com.skt.nugu.sdk.core.interfaces.message.MessageSender
-import com.skt.nugu.sdk.core.interfaces.message.Status
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
 class MakeCallDirectiveHandler(
@@ -120,13 +118,9 @@ class MakeCallDirectiveHandler(
         // no-op
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[MAKE_CALL] = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[MAKE_CALL] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO
         )
-
-        return configurations
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/SendCandidatesDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/ext/phonecall/handler/SendCandidatesDirectiveHandler.kt
@@ -22,7 +22,6 @@ import com.skt.nugu.sdk.agent.ext.phonecall.Context
 import com.skt.nugu.sdk.agent.ext.phonecall.PhoneCallAgent
 import com.skt.nugu.sdk.agent.ext.phonecall.payload.SendCandidatesPayload
 import com.skt.nugu.sdk.agent.util.IgnoreErrorContextRequestor
-import com.skt.nugu.sdk.agent.util.MessageFactory
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 import com.skt.nugu.sdk.core.interfaces.context.BaseContextState
 import com.skt.nugu.sdk.core.interfaces.context.ContextGetterInterface
@@ -46,8 +45,7 @@ class SendCandidatesDirectiveHandler(
         private const val NAME_SEND_CANDIDATES = "SendCandidates"
         private const val NAME_CANDIDATES_LISTED = "CandidatesListed"
 
-        private val SEND_CANDIDATES =
-            NamespaceAndName(PhoneCallAgent.NAMESPACE, NAME_SEND_CANDIDATES)
+        private val SEND_CANDIDATES = NamespaceAndName(PhoneCallAgent.NAMESPACE, NAME_SEND_CANDIDATES)
     }
 
     interface Callback {
@@ -139,11 +137,7 @@ class SendCandidatesDirectiveHandler(
         // no-op
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[SEND_CANDIDATES] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[SEND_CANDIDATES] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/location/LocationAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/location/LocationAgent.kt
@@ -55,11 +55,11 @@ class LocationAgent(
 
     private var contextUpdateLock = ReentrantLock()
 
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
+
     init {
         contextStateProviderRegistry.setStateProvider(namespaceAndName, this)
     }
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     internal data class StateContext(private val location: Location?) : BaseContextState {
         companion object {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/nudge/NudgeAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/nudge/NudgeAgent.kt
@@ -19,6 +19,7 @@ package com.skt.nugu.sdk.agent.nudge
 import com.google.gson.JsonObject
 import com.skt.nugu.sdk.agent.DefaultASRAgent
 import com.skt.nugu.sdk.agent.DefaultTTSAgent
+import com.skt.nugu.sdk.agent.battery.DefaultBatteryAgent
 import com.skt.nugu.sdk.agent.display.DisplayAgent
 import com.skt.nugu.sdk.agent.nudge.NudgeDirectiveHandler.Companion.isAppendDirective
 import com.skt.nugu.sdk.agent.version.Version
@@ -75,6 +76,8 @@ class NudgeAgent(
     private val executor = Executors.newSingleThreadExecutor()
     internal var nudgeData: NudgeData? = null
 
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
+
     init {
         contextManager.setStateProvider(namespaceAndName, this)
         playSynchronizer.addListener(object : PlaySynchronizerInterface.Listener {
@@ -97,8 +100,6 @@ class NudgeAgent(
             }
         })
     }
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     override fun provideState(
         contextSetter: ContextSetterInterface,

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/nudge/NudgeDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/nudge/NudgeDirectiveHandler.kt
@@ -38,10 +38,6 @@ class NudgeDirectiveHandler(private val nudgeDirectiveObserver: NudgeDirectiveOb
         val nudgeInfo: JsonObject
     )
 
-    private val config: Map<NamespaceAndName, BlockingPolicy> by lazy {
-        HashMap<NamespaceAndName, BlockingPolicy>().apply { this[APPEND] = BlockingPolicy.sharedInstanceFactory.get() }
-    }
-
     override fun preHandleDirective(info: DirectiveInfo) {
         // skip
     }
@@ -60,5 +56,9 @@ class NudgeDirectiveHandler(private val nudgeDirectiveObserver: NudgeDirectiveOb
         // skip
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> = config
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> by lazy {
+        HashMap<NamespaceAndName, BlockingPolicy>().apply {
+            this[APPEND] = BlockingPolicy.sharedInstanceFactory.get()
+        }
+    }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/permission/PermissionAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/permission/PermissionAgent.kt
@@ -66,11 +66,11 @@ class PermissionAgent(
         }.toString()
     }
 
-    init {
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
+
+        init {
         contextManager.setStateProvider(namespaceAndName, this)
     }
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     override fun provideState(
         contextSetter: ContextSetterInterface,

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/permission/RequestPermissionDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/permission/RequestPermissionDirectiveHandler.kt
@@ -79,11 +79,7 @@ class RequestPermissionDirectiveHandler(
         // can't cancel.
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[DIRECTIVE] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[DIRECTIVE] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/routine/RoutineAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/routine/RoutineAgent.kt
@@ -372,7 +372,7 @@ class RoutineAgent(
     private var causingPauseRequests = HashMap<String, EventMessageRequest>()
     var textAgent: TextAgentInterface? = null
 
-    override fun getInterfaceName(): String = NAMESPACE
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
 
     init {
         directiveSequencer.addDirectiveHandler(StartDirectiveHandler(this, startDirectiveHandleController))

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/routine/handler/ContinueDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/routine/handler/ContinueDirectiveHandler.kt
@@ -110,13 +110,9 @@ class ContinueDirectiveHandler(
         // no-op
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[CONTINUE] = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[CONTINUE] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO
         )
-
-        return configurations
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/routine/handler/StartDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/routine/handler/StartDirectiveHandler.kt
@@ -138,11 +138,7 @@ class StartDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[START] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[START] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/routine/handler/StopDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/routine/handler/StopDirectiveHandler.kt
@@ -94,11 +94,7 @@ class StopDirectiveHandler(
         // no-op
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[STOP] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configurations
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[STOP] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/session/SessionAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/session/SessionAgent.kt
@@ -45,12 +45,12 @@ class SessionAgent(
 
     private val executor = Executors.newSingleThreadExecutor()
 
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
+
     init {
         contextStateProviderRegistry.setStateProvider(namespaceAndName, this)
         directiveSequencer.addDirectiveHandler(SetDirectiveHandler(this))
     }
-
-    override fun getInterfaceName(): String = NAMESPACE
 
     internal data class StateContext(
         val sessions: Set<SessionManagerInterface.Session>

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/session/handler/SetDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/session/handler/SetDirectiveHandler.kt
@@ -70,11 +70,7 @@ class SetDirectiveHandler(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[SET] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[SET] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/sound/SoundAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/sound/SoundAgent.kt
@@ -224,15 +224,11 @@ class SoundAgent(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[BEEP] = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[BEEP] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_AUDIO,
             BlockingPolicy.MEDIUM_AUDIO_ONLY
         )
-
-        return configuration
     }
 
     private fun sendBeepSucceededEvent(playServiceId: String, referrerDialogRequestId: String) {

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/system/handler/RevokeDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/system/handler/RevokeDirectiveHandler.kt
@@ -63,11 +63,7 @@ class RevokeDirectiveHandler(
         // no-op
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[REVOKE] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[REVOKE] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/text/ExpectTypingDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/text/ExpectTypingDirectiveHandler.kt
@@ -60,13 +60,8 @@ internal class ExpectTypingDirectiveHandler(
         directives.remove(info.directive.header.messageId)
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> =
-        HashMap<NamespaceAndName, BlockingPolicy>().apply {
-            // only blocked by audio
-            put(
-                EXPECT_TYPING, BlockingPolicy(
-                    BlockingPolicy.MEDIUM_AUDIO
-                )
-            )
-        }
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        // only blocked by audio
+        this[EXPECT_TYPING] = BlockingPolicy(BlockingPolicy.MEDIUM_AUDIO)
+    }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/text/TextAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/text/TextAgent.kt
@@ -362,15 +362,10 @@ class TextAgent(
     override fun cancelDirective(info: DirectiveInfo) {
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
         val nonBlockingPolicy = BlockingPolicy.sharedInstanceFactory.get()
-
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[TEXT_SOURCE] = nonBlockingPolicy
-        configuration[TEXT_REDIRECT] = nonBlockingPolicy
-
-        return configuration
+        this[TEXT_SOURCE] = nonBlockingPolicy
+        this[TEXT_REDIRECT] = nonBlockingPolicy
     }
 
     override fun provideState(

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/tts/handler/StopDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/tts/handler/StopDirectiveHandler.kt
@@ -66,11 +66,7 @@ class StopDirectiveHandler(
 
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configuration = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configuration[STOP] = BlockingPolicy.sharedInstanceFactory.get()
-
-        return configuration
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[STOP] = BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/utility/UtilityAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/utility/UtilityAgent.kt
@@ -41,7 +41,7 @@ class UtilityAgent(
         private val COMPACT_STATE: String = buildCompactContext().toString()
     }
 
-    override fun getInterfaceName(): String = NAMESPACE
+    override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, NAMESPACE)
 
     private val contextState = object : BaseContextState {
         override fun value(): String = COMPACT_STATE

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/utility/handler/BlockDirectiveHandler.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/utility/handler/BlockDirectiveHandler.kt
@@ -66,14 +66,10 @@ class BlockDirectiveHandler: AbstractDirectiveHandler() {
         sleepFutureMap.remove(info.directive.getMessageId())?.cancel(true)
     }
 
-    override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> {
-        val configurations = HashMap<NamespaceAndName, BlockingPolicy>()
-
-        configurations[BLOCK] = BlockingPolicy.sharedInstanceFactory.get(
+    override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+        this[BLOCK] = BlockingPolicy.sharedInstanceFactory.get(
             BlockingPolicy.MEDIUM_ALL,
             BlockingPolicy.MEDIUM_ANY_ONLY
         )
-
-        return configurations
     }
 }

--- a/nugu-agent/src/test/java/com/skt/nugu/sdk/agent/location/LocationAgentTest.kt
+++ b/nugu-agent/src/test/java/com/skt/nugu/sdk/agent/location/LocationAgentTest.kt
@@ -37,7 +37,7 @@ class LocationAgentTest {
     @Test
     fun testGetInterfaceName() {
         val agent = LocationAgent(mock(), mock())
-        Assert.assertTrue(agent.getInterfaceName() == LocationAgent.NAMESPACE)
+        Assert.assertTrue(agent.namespaceAndName.name == LocationAgent.NAMESPACE)
     }
 
     @Test

--- a/nugu-agent/src/test/java/com/skt/nugu/sdk/agent/permission/PermissionAgentTest.kt
+++ b/nugu-agent/src/test/java/com/skt/nugu/sdk/agent/permission/PermissionAgentTest.kt
@@ -39,7 +39,7 @@ class PermissionAgentTest {
     @Test
     fun testGetInterfaceName() {
         val agent = PermissionAgent(mock(), mock())
-        Assert.assertTrue(agent.getInterfaceName() == PermissionAgent.NAMESPACE)
+        Assert.assertTrue(agent.namespaceAndName.name == PermissionAgent.NAMESPACE)
     }
 
     @Test

--- a/nugu-agent/src/test/java/com/skt/nugu/sdk/agent/permission/RequestPermissionDirectiveHandlerTest.kt
+++ b/nugu-agent/src/test/java/com/skt/nugu/sdk/agent/permission/RequestPermissionDirectiveHandlerTest.kt
@@ -79,7 +79,7 @@ class RequestPermissionDirectiveHandlerTest {
     @Test
     fun testGetConfiguration() {
         val handler = RequestPermissionDirectiveHandler(mock())
-        handler.getConfiguration().let {
+        handler.configurations().let {
             val requestPermission = it[RequestPermissionDirectiveHandler.DIRECTIVE]
             Assert.assertTrue(requestPermission != null)
             requestPermission?.let { blockingPolicy ->

--- a/nugu-agent/src/test/java/com/skt/nugu/sdk/agent/permission/RequestPermissionDirectiveHandlerTest.kt
+++ b/nugu-agent/src/test/java/com/skt/nugu/sdk/agent/permission/RequestPermissionDirectiveHandlerTest.kt
@@ -79,7 +79,7 @@ class RequestPermissionDirectiveHandlerTest {
     @Test
     fun testGetConfiguration() {
         val handler = RequestPermissionDirectiveHandler(mock())
-        handler.configurations().let {
+        handler.configurations.let {
             val requestPermission = it[RequestPermissionDirectiveHandler.DIRECTIVE]
             Assert.assertTrue(requestPermission != null)
             requestPermission?.let { blockingPolicy ->

--- a/nugu-core/src/main/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveRouter.kt
+++ b/nugu-core/src/main/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveRouter.kt
@@ -70,11 +70,11 @@ class DirectiveRouter {
     }
 
     private fun getDirectiveHandler(directive: Directive): DirectiveHandler? {
-        return handlers.find { it.getConfiguration().containsKey(directive.getNamespaceAndName()) }
+        return handlers.find { it.configurations.containsKey(directive.getNamespaceAndName()) }
     }
 
     fun getPolicy(directive: Directive): BlockingPolicy {
-        return getDirectiveHandler(directive)?.getConfiguration()?.get(directive.getNamespaceAndName())
+        return getDirectiveHandler(directive)?.configurations?.get(directive.getNamespaceAndName())
             ?: BlockingPolicy.sharedInstanceFactory.get()
     }
 }

--- a/nugu-core/src/main/java/com/skt/nugu/sdk/core/playstack/PlayStackContextManager.kt
+++ b/nugu-core/src/main/java/com/skt/nugu/sdk/core/playstack/PlayStackContextManager.kt
@@ -40,7 +40,7 @@ class PlayStackContextManager(
         internal const val PROVIDER_NAME = "playStack"
     }
 
-    override fun getName(): String = PROVIDER_NAME
+    override val namespaceAndName: NamespaceAndName = NamespaceAndName(ClientContextProvider.NAMESPACE, PROVIDER_NAME)
 
     private val executor = Executors.newSingleThreadExecutor()
 

--- a/nugu-core/src/test/java/com/skt/nugu/sdk/core/context/ContextManagerTest.kt
+++ b/nugu-core/src/test/java/com/skt/nugu/sdk/core/context/ContextManagerTest.kt
@@ -29,7 +29,7 @@ import org.mockito.kotlin.*
 class ContextManagerTest {
 
     private val audioPlayerContextProvider = object: SupportedInterfaceContextProvider {
-        override fun getInterfaceName(): String = "AudioPlayer"
+        override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, "AudioPlayer")
 
         override fun provideState(
             contextSetter: ContextSetterInterface,
@@ -50,7 +50,7 @@ class ContextManagerTest {
     }
 
     private val ttsContextProvider = object: SupportedInterfaceContextProvider {
-        override fun getInterfaceName(): String = "TTS"
+        override val namespaceAndName = NamespaceAndName(SupportedInterfaceContextProvider.NAMESPACE, "TTS")
 
         override fun provideState(
             contextSetter: ContextSetterInterface,

--- a/nugu-core/src/test/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveRouterTest.kt
+++ b/nugu-core/src/test/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveRouterTest.kt
@@ -40,7 +40,7 @@ class DirectiveRouterTest {
         ), "{}")
 
         init {
-            whenever(HANDLER.getConfiguration()).thenReturn(mutableMapOf<NamespaceAndName, BlockingPolicy>().apply{
+            whenever(HANDLER.configurations).thenReturn(mutableMapOf<NamespaceAndName, BlockingPolicy>().apply{
                 put(DIRECTIVE.getNamespaceAndName(), BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO))
             })
         }
@@ -81,7 +81,7 @@ class DirectiveRouterTest {
         val router = DirectiveRouter()
         router.addDirectiveHandler(HANDLER)
 
-        Assert.assertEquals(HANDLER.getConfiguration()[DIRECTIVE.getNamespaceAndName()], router.getPolicy(DIRECTIVE))
-        verify(HANDLER, atLeastOnce()).getConfiguration()
+        Assert.assertEquals(HANDLER.configurations[DIRECTIVE.getNamespaceAndName()], router.getPolicy(DIRECTIVE))
+        verify(HANDLER, atLeastOnce()).configurations
     }
 }

--- a/nugu-core/src/test/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveSequencerTest.kt
+++ b/nugu-core/src/test/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveSequencerTest.kt
@@ -24,7 +24,10 @@ import com.skt.nugu.sdk.core.interfaces.directive.DirectiveSequencerInterface
 import com.skt.nugu.sdk.core.interfaces.message.Directive
 import com.skt.nugu.sdk.core.interfaces.message.Header
 import org.junit.Test
-import org.mockito.kotlin.*
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.timeout
+import org.mockito.kotlin.verify
 
 class DirectiveSequencerTest {
     companion object {
@@ -46,8 +49,8 @@ class DirectiveSequencerTest {
                 resultMap.remove(messageId)?.setFailed("")
             }
 
-            override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> = mutableMapOf<NamespaceAndName, BlockingPolicy>().apply{
-                put(DIRECTIVE_0.getNamespaceAndName(), BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO))
+            override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+                this[DIRECTIVE_0.getNamespaceAndName()] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
             }
         }
 
@@ -69,8 +72,8 @@ class DirectiveSequencerTest {
                 resultMap.remove(messageId)?.setFailed("")
             }
 
-            override fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy> = mutableMapOf<NamespaceAndName, BlockingPolicy>().apply{
-                put(DIRECTIVE_1.getNamespaceAndName(), BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO))
+            override val configurations: Map<NamespaceAndName, BlockingPolicy> = HashMap<NamespaceAndName, BlockingPolicy>().apply {
+                this[DIRECTIVE_1.getNamespaceAndName()] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
             }
         }
 

--- a/nugu-core/src/test/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveSequencerTest.kt
+++ b/nugu-core/src/test/java/com/skt/nugu/sdk/core/directivesequencer/DirectiveSequencerTest.kt
@@ -31,6 +31,24 @@ import org.mockito.kotlin.verify
 
 class DirectiveSequencerTest {
     companion object {
+        private val DIRECTIVE_0 = Directive(null, Header(
+            "dialogRequestId",
+            "messageId_0",
+            "Play",
+            "AudioPlayer",
+            "1.0",
+            ""
+        ), "{}")
+
+        private val DIRECTIVE_1 = Directive(null, Header(
+            "dialogRequestId",
+            "messageId_1",
+            "Play",
+            "TTS",
+            "1.0",
+            ""
+        ), "{}")
+
         private val HANDLER_0: DirectiveHandler = object : DirectiveHandler {
             val resultMap = HashMap<String, DirectiveHandlerResult>()
 
@@ -76,24 +94,6 @@ class DirectiveSequencerTest {
                 this[DIRECTIVE_1.getNamespaceAndName()] = BlockingPolicy.sharedInstanceFactory.get(BlockingPolicy.MEDIUM_AUDIO)
             }
         }
-
-        private val DIRECTIVE_0 = Directive(null, Header(
-            "dialogRequestId",
-            "messageId_0",
-            "Play",
-            "AudioPlayer",
-            "1.0",
-            ""
-        ), "{}")
-
-        private val DIRECTIVE_1 = Directive(null, Header(
-            "dialogRequestId",
-            "messageId_1",
-            "Play",
-            "TTS",
-            "1.0",
-            ""
-        ), "{}")
     }
 
     @Test

--- a/nugu-core/src/test/java/com/skt/nugu/sdk/core/playstack/PlayStackContextManagerTest.kt
+++ b/nugu-core/src/test/java/com/skt/nugu/sdk/core/playstack/PlayStackContextManagerTest.kt
@@ -35,7 +35,7 @@ class PlayStackContextManagerTest {
     @Test
     fun testGetName() {
         val contextProvider = PlayStackContextManager(mock(), mock())
-        Assert.assertTrue(contextProvider.getName() == PlayStackContextManager.PROVIDER_NAME)
+        Assert.assertTrue(contextProvider.namespaceAndName.name == PlayStackContextManager.PROVIDER_NAME)
     }
 
     @Test

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/ClientContextProvider.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/ClientContextProvider.kt
@@ -16,14 +16,12 @@
 
 package com.skt.nugu.sdk.core.interfaces.context
 
-import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 
 /**
  * Interface to provide context of client's element
  */
 interface ClientContextProvider : ContextStateProvider {
-    override val namespaceAndName: NamespaceAndName
-        get() = NamespaceAndName("client", getName())
-
-    fun getName(): String
+    companion object{
+        const val NAMESPACE = "client"
+    }
 }

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/OsContextProvider.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/OsContextProvider.kt
@@ -31,7 +31,7 @@ abstract class OsContextProvider: ClientContextProvider {
         override fun value(): String = "\"${type.value}\""
     }
 
-    final override fun getName(): String = "os"
+    override val namespaceAndName: NamespaceAndName = NamespaceAndName(ClientContextProvider.NAMESPACE, "os")
 
     final override fun provideState(
         contextSetter: ContextSetterInterface,

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/SupportedInterfaceContextProvider.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/SupportedInterfaceContextProvider.kt
@@ -16,14 +16,11 @@
 
 package com.skt.nugu.sdk.core.interfaces.context
 
-import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
-
 /**
  * Interface to provide context of supportedInterfaces's element
  */
 interface SupportedInterfaceContextProvider : ContextStateProvider {
-    override val namespaceAndName: NamespaceAndName
-        get() = NamespaceAndName("supportedInterfaces", getInterfaceName())
-
-    fun getInterfaceName(): String
+    companion object{
+        const val NAMESPACE = "supportedInterfaces"
+    }
 }

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/WakeupWordContextProvider.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/context/WakeupWordContextProvider.kt
@@ -19,8 +19,8 @@ package com.skt.nugu.sdk.core.interfaces.context
 import com.skt.nugu.sdk.core.interfaces.common.NamespaceAndName
 
 abstract class WakeupWordContextProvider : ClientContextProvider {
-    override fun getName(): String = "wakeupWord"
-
+    override val namespaceAndName: NamespaceAndName = NamespaceAndName(ClientContextProvider.NAMESPACE, "wakeupWord")
+    
     override fun provideState(
         contextSetter: ContextSetterInterface,
         namespaceAndName: NamespaceAndName,

--- a/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/directive/DirectiveHandler.kt
+++ b/nugu-interface/src/main/java/com/skt/nugu/sdk/core/interfaces/directive/DirectiveHandler.kt
@@ -43,5 +43,5 @@ interface DirectiveHandler {
      *
      * @return namespace and name for directive which can handle and it's blocking policy.
      */
-    fun getConfiguration(): Map<NamespaceAndName, BlockingPolicy>
+    val configurations : Map<NamespaceAndName, BlockingPolicy>
 }

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/controller/TemplateMediaHandler.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/controller/TemplateMediaHandler.kt
@@ -72,7 +72,7 @@ open class TemplateMediaHandler(
     @VisibleForTesting
     internal val directiveHandlingListener = object : DirectiveSequencerInterface.OnDirectiveHandlingListener {
         private fun Directive.isAudioPlayerPauseDirective(): Boolean {
-            return getNamespaceAndName() == NamespaceAndName(DefaultAudioPlayerAgent.NAMESPACE, DefaultAudioPlayerAgent.NAME_PAUSE)
+            return getNamespace() == DefaultAudioPlayerAgent.NAMESPACE && getName() == DefaultAudioPlayerAgent.NAME_PAUSE
         }
 
         override fun onCompleted(directive: Directive) {

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/widget/NuguChipsView.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/widget/NuguChipsView.kt
@@ -209,8 +209,7 @@ class NuguChipsView @JvmOverloads constructor(
          */
         override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ChipsViewHolder {
             val layout = if (viewType == Chip.Type.NUDGE.ordinal) R.layout.item_text_nudge else R.layout.item_text
-            val viewHolder = ChipsViewHolder(LayoutInflater.from(context).inflate(layout, viewGroup, false))
-            return viewHolder
+            return ChipsViewHolder(LayoutInflater.from(context).inflate(layout, viewGroup, false))
         }
 
         /**
@@ -242,9 +241,7 @@ class NuguChipsView @JvmOverloads constructor(
                     holder.titleView.setBackgroundResource(defaultDrawableId)
                 }
             }
-            holder.titleView.setThrottledOnClickListener {
-                listener?.onClick(items[position])
-            }
+
         }
 
         fun startNudgeAnimationIfNeeded() {
@@ -267,6 +264,12 @@ class NuguChipsView @JvmOverloads constructor(
              * A textview representing the title
              * */
             val titleView: TextView = itemView.findViewById(R.id.tv_chips)
+
+            init{
+                titleView.setThrottledOnClickListener {
+                    listener?.onClick(items[adapterPosition])
+                }
+            }
         }
     }
 

--- a/nugu-ux-kit/src/test/java/com/skt/nugu/sdk/platform/android/ux/template/controller/TemplateMediaHandlerTest.kt
+++ b/nugu-ux-kit/src/test/java/com/skt/nugu/sdk/platform/android/ux/template/controller/TemplateMediaHandlerTest.kt
@@ -144,18 +144,21 @@ class TemplateMediaHandlerTest {
     @Test
     fun testPauseDirective() {
         val directive: Directive = mock()
-        `when`(directive.getNamespaceAndName()).thenReturn(NamespaceAndName(DefaultAudioPlayerAgent.NAMESPACE, DefaultAudioPlayerAgent.NAME_PAUSE))
+        `when`(directive.getNamespace()).thenReturn(DefaultAudioPlayerAgent.NAMESPACE)
+        `when`(directive.getName()).thenReturn(DefaultAudioPlayerAgent.NAME_PAUSE)
         mediaTemplateHandler.directiveHandlingListener.onCompleted(directive)
         verify(clientListener).onMediaStateChanged(eq(AudioPlayerAgentInterface.State.PAUSED), any(), any(), eq(true))
 
         // check not PAUSE directive
-        `when`(directive.getNamespaceAndName()).thenReturn(NamespaceAndName("I'm not", "PAUSE"))
+        `when`(directive.getNamespace()).thenReturn("I'm not")
+        `when`(directive.getName()).thenReturn("PAUSE")
         mediaTemplateHandler.directiveHandlingListener.onCompleted(directive)
         verifyNoMoreInteractions(clientListener)
 
         // check null condition
         mediaTemplateHandler.setClientListener(null)
-        `when`(directive.getNamespaceAndName()).thenReturn(NamespaceAndName(DefaultAudioPlayerAgent.NAMESPACE, DefaultAudioPlayerAgent.NAME_PAUSE))
+        `when`(directive.getNamespace()).thenReturn(DefaultAudioPlayerAgent.NAMESPACE)
+        `when`(directive.getName()).thenReturn(DefaultAudioPlayerAgent.NAME_PAUSE)
         mediaTemplateHandler.directiveHandlingListener.onCompleted(directive)
         verifyNoMoreInteractions(clientListener)
 


### PR DESCRIPTION
- ClickListener in ChipsView
- NamespaeAndName objects are created in every referencing from ContextStateProvider and are created twice in every calling a getPolicy() method in DirectiveRouter.