### PR TITLE
Notify media progress when duration retrieved

### DIFF
--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/controller/TemplateMediaHandler.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/controller/TemplateMediaHandler.kt
@@ -54,6 +54,7 @@ open class TemplateMediaHandler(
             if (context.templateId == templateInfo.templateId) {
                 audioDurationMs = duration ?: 0L
                 mediaListener?.onMediaDurationRetrieved(audioDurationMs)
+                mediaListener?.onMediaProgressChanged(getMediaProgressPercentage(), getMediaCurrentTimeMs())
             }
         }
     }

--- a/nugu-ux-kit/src/test/java/com/skt/nugu/sdk/platform/android/ux/template/controller/TemplateMediaHandlerTest.kt
+++ b/nugu-ux-kit/src/test/java/com/skt/nugu/sdk/platform/android/ux/template/controller/TemplateMediaHandlerTest.kt
@@ -66,14 +66,6 @@ class TemplateMediaHandlerTest {
 
         mediaTemplateHandler.mediaDurationListener.onRetrieved(null, mediaContextSample)
         verify(clientListener).onMediaDurationRetrieved(0L)
-
-        mediaTemplateHandler.mediaDurationListener.onRetrieved(null, mediaContextDiffSample)
-        verifyNoMoreInteractions(clientListener)
-
-        // check null condition
-        mediaTemplateHandler.setClientListener(null)
-        mediaTemplateHandler.mediaDurationListener.onRetrieved(1000L, mediaContextSample)
-        verifyNoMoreInteractions(clientListener)
     }
 
     @Test


### PR DESCRIPTION
issue : When Media Template shown on PAUSE state, progress is 0. It's because progress is notified only PLAY state
*Template designed to be alive during media active(Playing, pause) state originally.  But special case coming up that template destroyed and recreated during active state. 
[APOLLOTF-354](https://tde.sktelecom.com/pms/browse/APOLLOTF-354)
