### PR TITLE
Fix onProgressReportDelay not called rarely. #2246

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/DefaultAudioPlayerAgent.kt
@@ -1279,7 +1279,7 @@ class DefaultAudioPlayerAgent(
         when (currentActivity) {
             AudioPlayerAgentInterface.State.PLAYING -> {
                 sendPlaybackFinishedEvent()
-                progressTimer.stop()
+                progressTimer.finish()
 
                 val audioInfoContext = createAudioInfoContext()
                 audioInfoContext?.let { context->


### PR DESCRIPTION
Problem
* If the time when 'onProgressReportDelay' is called and the time at which the audio playback ends are same,
ProgressTimer may be canceled rarely.

Solve
* A finish() API was added to ensure onProgressReportDelay()'s call.