### PR TITLE
Fix weird fast scrolling when dragging first item on playlist.

### DIFF
--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/view/media/playlist/PlaylistFragment.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/view/media/playlist/PlaylistFragment.kt
@@ -54,6 +54,7 @@ class PlaylistFragment : Fragment(), PlaylistDataListener {
 
             if (from in 0 until adapter.itemCount && to in 0 until adapter.itemCount) {
                 viewModel.moveItem(from, to)
+                adapter.moveData(from, to)
                 return true
             }
 
@@ -184,10 +185,6 @@ class PlaylistFragment : Fragment(), PlaylistDataListener {
 
         viewModel.removePlaylistItem.collectCancelable {
             adapter.removeItem(it)
-        }
-
-        viewModel.movePlaylistItem.collectCancelable {
-            adapter.moveData(it.first, it.second)
         }
 
         viewModel.title.collectCancelable {

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/view/media/playlist/PlaylistViewModel.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/view/media/playlist/PlaylistViewModel.kt
@@ -36,9 +36,6 @@ class PlaylistViewModel : ViewModel() {
     private val _updatePlaylistItem = MutableSharedFlow<Int>()
     val updatePlaylistItem = _updatePlaylistItem.asSharedFlow()
 
-    private val _movePlaylistItem = MutableSharedFlow<Pair<Int, Int>>()  //from, to
-    val movePlaylistItem = _movePlaylistItem.asSharedFlow()
-
     private val _removePlaylistItem = MutableSharedFlow<List<Int>>()
     val removePlaylistItem = _removePlaylistItem.asSharedFlow()
 
@@ -162,11 +159,6 @@ class PlaylistViewModel : ViewModel() {
             runCatching {
                 val removed = _playlist.value.removeAt(from)
                 _playlist.value.add(to, removed)
-            }.onSuccess {
-                CoroutineScope(Dispatchers.Main).launch {
-                    _movePlaylistItem.emit(from to to)
-                }
-
                 onListChanged()
             }
         }

--- a/nugu-ux-kit/src/main/res/layout/nugu_fragment_playlist.xml
+++ b/nugu-ux-kit/src/main/res/layout/nugu_fragment_playlist.xml
@@ -46,9 +46,9 @@
 
                 <TextView
                     android:id="@+id/btn_edit"
-                    android:layout_marginStart="10dp"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
                     android:background="@drawable/nugu_bg_round_corner_100_blue"
                     android:paddingHorizontal="12dp"
                     android:paddingVertical="4dp"
@@ -99,9 +99,9 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/view_play_list"
             android:layout_width="match_parent"
-            android:overScrollMode="never"
             android:layout_height="match_parent"
-            android:background="@color/nugu_playlist_bg" />
+            android:background="@color/nugu_playlist_bg"
+            android:overScrollMode="never" />
     </androidx.appcompat.widget.LinearLayoutCompat>
 
     <LinearLayout


### PR DESCRIPTION
reason: onMove callback on ItemTouchHelper must return true after Adapter updated. But It wasn't. Because the process occurs asynchronously. 

solution:  Change onMove callback to update Adapter directly and then return true.  