### PR TITLE
Fix right top image not visible when adult only music playing

### DIFF
--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/TemplateExtension.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/TemplateExtension.kt
@@ -45,6 +45,8 @@ fun ImageView.updateImage(
 ) {
     if (isMerge && url.isNullOrBlank()) return
 
+    visibility = if (url != null) View.VISIBLE else View.GONE
+
     post {
         Glide.with(context).load(url)
             .override(measuredWidth, measuredHeight)

--- a/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/view/media/DisplayAudioPlayer.kt
+++ b/nugu-ux-kit/src/main/java/com/skt/nugu/sdk/platform/android/ux/template/view/media/DisplayAudioPlayer.kt
@@ -907,8 +907,8 @@ open class DisplayAudioPlayer constructor(
     }
 
     open fun loadPlaylistButton(albumCoverUrl: String?) {
-        btnShowPlaylist?.visibility = if (isPlayListSupport) View.VISIBLE else View.GONE
         btnHidePlaylist?.updateImage(albumCoverUrl, thumbTransformCornerBtnHidePlaylist, false)
+        btnShowPlaylist?.visibility = if (isPlayListSupport) View.VISIBLE else View.GONE
     }
 
     open fun getPlaylistBottomMargin(): Int {

--- a/nugu-ux-kit/src/test/java/com/skt/nugu/sdk/platform/android/ux/template/TemplateExtensionTest.kt
+++ b/nugu-ux-kit/src/test/java/com/skt/nugu/sdk/platform/android/ux/template/TemplateExtensionTest.kt
@@ -70,7 +70,7 @@ class TemplateExtensionTest {
         assertEquals(imageView.visibility, View.VISIBLE)
 
         imageView.updateImage(null, null, isMerge = false)
-        assertEquals(imageView.visibility, View.VISIBLE)
+        assertEquals(imageView.visibility, View.GONE)
 
         imageView.updateImage("temp url", null, isMerge = false)
         assertEquals(imageView.visibility, View.VISIBLE)


### PR DESCRIPTION
Originally the code below was there in updateImage() function.
         `visibility = if (url != null) View.VISIBLE else View.GONE`
But when I did Playlist implementation, I thought It is not necessary and removed it. 
And It makes side effect now, so I recover it.
