### PR TITLE
Cancel ASR's Recognize event after ASR finished. #2506

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/SpeechRecognizer.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/SpeechRecognizer.kt
@@ -19,6 +19,7 @@ import com.skt.nugu.sdk.agent.DefaultASRAgent
 import com.skt.nugu.sdk.agent.asr.audio.AudioFormat
 import com.skt.nugu.sdk.agent.sds.SharedDataStream
 import com.skt.nugu.sdk.core.interfaces.dialog.DialogAttribute
+import com.skt.nugu.sdk.core.interfaces.message.Call
 import com.skt.nugu.sdk.core.interfaces.message.Directive
 import com.skt.nugu.sdk.core.interfaces.message.request.EventMessageRequest
 
@@ -45,6 +46,12 @@ interface SpeechRecognizer {
     interface Request {
         val eventMessage: EventMessageRequest
         val attributeKey: String?
+
+        /**
+         * Recommend call this on inactive state([State.isActive]).
+         * If active state, call [stop] instead.
+         */
+        fun cancelRequest()
     }
 
     fun start(

--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/impl/DefaultClientSpeechRecognizer.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/impl/DefaultClientSpeechRecognizer.kt
@@ -68,6 +68,7 @@ class DefaultClientSpeechRecognizer(
         val resultListener: ASRAgentInterface.OnResultListener?
     ): SpeechRecognizer.Request {
         override val attributeKey: String? = expectSpeechParam?.directive?.header?.messageId
+
         var errorTypeForCausingEpdStop: ASRAgentInterface.ErrorType? = null
 
         var stopByCancel: Boolean? = null
@@ -78,6 +79,14 @@ class DefaultClientSpeechRecognizer(
 
         val eventMessageHeader = with(eventMessage) {
             Header(dialogRequestId, messageId, name, namespace, version, referrerDialogRequestId)
+        }
+
+        override fun cancelRequest() {
+            recognizeEventCall?.let {
+                if(!it.isCanceled()) {
+                    it.cancel()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
* Even if finish ASR, async's response(directives) will be arrived on event channel. To cancel(close) this channel, add API at Request.