### PR TITLE
Cancel ASR's Recognize event after ASR finished. #2506

### DIFF
--- a/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/ASRAgentInterface.kt
+++ b/nugu-agent/src/main/java/com/skt/nugu/sdk/agent/asr/ASRAgentInterface.kt
@@ -217,6 +217,12 @@ interface ASRAgentInterface {
             ERROR_TAKE_TOO_LONG_START_RECOGNITION,
             ERROR_UNKNOWN
         }
+
+        interface Cancellable {
+            fun cancel()
+        }
+
+        fun onCancellableRetrieved(cancelable: Cancellable) = Unit
     }
 
     /**


### PR DESCRIPTION
    * Even if finish ASR, async's response(directives) will be arrived on event channel.
      To cancel(close) this channel, add API at Request.