### PR TITLE
Fix side effect of issue-2517

### DIFF
--- a/nugu-core/src/main/java/com/skt/nugu/sdk/core/focus/FocusManager.kt
+++ b/nugu-core/src/main/java/com/skt/nugu/sdk/core/focus/FocusManager.kt
@@ -175,7 +175,7 @@ class FocusManager(
                         setChannelFocus(currentForegroundChannel, FocusState.BACKGROUND)
                         setChannelFocus(channelToAcquire, FocusState.FOREGROUND)
                     } else {
-                        setChannelFocus(currentForegroundChannel, FocusState.BACKGROUND)
+                        setChannelFocus(channelToAcquire, FocusState.BACKGROUND)
                     }
                 }
             }


### PR DESCRIPTION
* If failed to acquire external focus, the channelToAcquire's focus should be 'Background'.