### PR TITLE
Improve FocusManger's focus handling #2537

### DIFF
--- a/nugu-core/src/main/java/com/skt/nugu/sdk/core/focus/FocusManager.kt
+++ b/nugu-core/src/main/java/com/skt/nugu/sdk/core/focus/FocusManager.kt
@@ -159,8 +159,11 @@ class FocusManager(
 
         when {
             currentForegroundChannel == null || currentForegroundChannel == channelToAcquire -> {
-                acquireExternalFocus(channelToAcquire)
-                setChannelFocus(channelToAcquire, FocusState.FOREGROUND)
+                if(acquireExternalFocus(channelToAcquire)) {
+                    setChannelFocus(channelToAcquire, FocusState.FOREGROUND)
+                } else {
+                    setChannelFocus(channelToAcquire, FocusState.BACKGROUND)
+                }
             }
             channelToAcquire.priority.acquire <= currentForegroundChannel.priority.release -> {
                 val higherPriorityChannelExceptForegroundChannel = synchronized(activeChannels) {


### PR DESCRIPTION
* When failed to acquire external focus, set channel's focus on BACKGROUND